### PR TITLE
feat: sample-images-s3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,10 @@ ENV=dev
 DATABASE_URL=postgresql+psycopg2://postgres:postgres@db:5432/celumadb
 JWT_SECRET=changeme
 JWT_EXPIRES_MIN=480
+
+AWS_ACCESS_KEY_ID=AKIA...
+AWS_SECRET_ACCESS_KEY=xxxxxxxx
+AWS_REGION=us-east-1
+S3_BUCKET_NAME=your-bucket
+
+MEDIA_PUBLIC_BASE_URL=https://dxxxxxxxxxxxxx.cloudfront.net

--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,6 @@ AWS_REGION=us-east-1
 S3_BUCKET_NAME=your-bucket
 
 MEDIA_PUBLIC_BASE_URL=https://dxxxxxxxxxxxxx.cloudfront.net
+
+# MEDIA_PRESIGNED_EXPIRE_SECONDS=3600
+# S3_ENDPOINT_URL=http://localhost:4566

--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ JWT_EXPIRES_MIN=480
 
 AWS_ACCESS_KEY_ID=AKIA...
 AWS_SECRET_ACCESS_KEY=xxxxxxxx
-AWS_REGION=us-east-1
+AWS_REGION=mx-central-1
 S3_BUCKET_NAME=your-bucket
 
 MEDIA_PUBLIC_BASE_URL=https://dxxxxxxxxxxxxx.cloudfront.net

--- a/API_ENDPOINTS.md
+++ b/API_ENDPOINTS.md
@@ -487,6 +487,56 @@ The API is designed with JSON request bodies for all POST endpoints, providing:
 ]
 ```
 
+### POST /api/v1/laboratory/samples/{sample_id}/images
+**Upload a sample image (RAW or regular) and create renditions**
+
+**Request:**
+- Content-Type: `multipart/form-data`
+- Body: field `file` with the image file
+
+**Behavior:**
+- RAW formats (e.g., CR2/NEF/ARW/DNG): store RAW original + processed JPEG + thumbnail
+- Regular images (e.g., JPG/PNG/WebP): store processed JPEG + thumbnail
+
+**Response:**
+```json
+{
+  "message": "Image uploaded successfully",
+  "sample_image_id": "image-uuid",
+  "filename": "photo.dng",
+  "is_raw": true,
+  "file_size": 4567890,
+  "urls": {
+    "processed": "https://cdn.example.com/samples/<tenant>/<branch>/<sample>/processed/file.jpg",
+    "thumbnail": "https://cdn.example.com/samples/<tenant>/<branch>/<sample>/thumbnails/file.jpg",
+    "raw": "https://cdn.example.com/samples/<tenant>/<branch>/<sample>/raw/file.dng"
+  }
+}
+```
+
+### GET /api/v1/laboratory/samples/{sample_id}/images
+**List sample images and rendition URLs**
+
+**Response:**
+```json
+{
+  "sample_id": "sample-uuid",
+  "images": [
+    {
+      "id": "image-uuid",
+      "label": null,
+      "is_primary": false,
+      "created_at": "2025-08-18T10:00:00Z",
+      "urls": {
+        "processed": "https://cdn.example.com/.../processed/file.jpg",
+        "thumbnail": "https://cdn.example.com/.../thumbnails/file.jpg",
+        "original_raw": "https://cdn.example.com/.../raw/file.dng"
+      }
+    }
+  ]
+}
+```
+
 ## 📋 Report Management
 
 ### POST /api/v1/reports/

--- a/API_EXAMPLES.md
+++ b/API_EXAMPLES.md
@@ -415,6 +415,50 @@ if response.status_code == 200:
     print(f"Sample created: {sample['sample_code']}")
 ```
 
+### Upload Sample Image (multipart/form-data)
+```bash
+curl -X POST "http://localhost:8000/api/v1/laboratory/samples/SAMPLE_UUID/images" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -F "file=@/path/to/image.dng"
+```
+
+**Python Example:**
+```python
+import requests
+
+sample_id = "SAMPLE_UUID"
+filepath = "/path/to/image.dng"
+
+with open(filepath, "rb") as f:
+    resp = requests.post(
+        f"http://localhost:8000/api/v1/laboratory/samples/{sample_id}/images",
+        headers={"Authorization": f"Bearer {access_token}"},
+        files={"file": (filepath.split("/")[-1], f, "application/octet-stream")},
+    )
+
+resp.raise_for_status()
+data = resp.json()
+print("Uploaded:", data["filename"], "Processed URL:", data["urls"].get("processed"))
+```
+
+### List Sample Images
+```bash
+curl "http://localhost:8000/api/v1/laboratory/samples/SAMPLE_UUID/images" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
+**Python Example:**
+```python
+resp = requests.get(
+    f"http://localhost:8000/api/v1/laboratory/samples/{sample_id}/images",
+    headers={"Authorization": f"Bearer {access_token}"},
+)
+resp.raise_for_status()
+images = resp.json()["images"]
+for img in images:
+    print("Thumb:", img["urls"].get("thumbnail"), "Processed:", img["urls"].get("processed"))
+```
+
 ## 📋 Report Management
 
 ### Create Report

--- a/DEPLOYMENT_QUICKSTART.md
+++ b/DEPLOYMENT_QUICKSTART.md
@@ -62,6 +62,15 @@ JWT_SECRET=your-secret-key
 JWT_EXPIRES_MIN=480
 APP_NAME=celuma
 ENV=production
+
+# AWS / Media (for image uploads)
+AWS_ACCESS_KEY_ID=your-access-key
+AWS_SECRET_ACCESS_KEY=your-secret
+AWS_REGION=us-east-1
+S3_BUCKET_NAME=your-bucket
+MEDIA_PUBLIC_BASE_URL=https://dxxxxxxxxxxxx.cloudfront.net
+# MEDIA_PRESIGNED_EXPIRE_SECONDS=3600
+# S3_ENDPOINT_URL=http://localhost:4566
 ```
 
 ## 📚 Full Documentation

--- a/DEPLOYMENT_README.md
+++ b/DEPLOYMENT_README.md
@@ -202,6 +202,21 @@ APP_NAME=celuma
 
 # Environment (default: production)
 ENV=production
+
+# AWS / Media (image uploads)
+AWS_ACCESS_KEY_ID=your-access-key
+AWS_SECRET_ACCESS_KEY=your-secret
+AWS_REGION=us-east-1
+S3_BUCKET_NAME=your-bucket
+
+# Public media base URL (CDN/CloudFront)
+MEDIA_PUBLIC_BASE_URL=https://dxxxxxxxxxxxx.cloudfront.net
+
+# Presigned expiry (if using presigned links)
+MEDIA_PRESIGNED_EXPIRE_SECONDS=3600
+
+# Custom S3 endpoint (LocalStack/MinIO)
+# S3_ENDPOINT_URL=http://localhost:4566
 ```
 
 ### Environment File Example

--- a/README.md
+++ b/README.md
@@ -268,6 +268,22 @@ JWT_SECRET=your-super-secret-jwt-key
 JWT_EXPIRES_MIN=480
 APP_NAME=celuma
 ENV=production
+
+# AWS S3 (required for image uploads)
+AWS_ACCESS_KEY_ID=your-aws-access-key
+AWS_SECRET_ACCESS_KEY=your-aws-secret
+AWS_REGION=us-east-1
+S3_BUCKET_NAME=your-bucket-name
+
+# Media / CDN (optional)
+# Use CloudFront or CDN base URL for permanent public links
+MEDIA_PUBLIC_BASE_URL=https://dxxxxxxxxxxxx.cloudfront.net
+
+# Presigned URL expiry in seconds (used if generating presigned links)
+MEDIA_PRESIGNED_EXPIRE_SECONDS=3600
+
+# Custom S3 endpoint (LocalStack/MinIO)
+# S3_ENDPOINT_URL=http://localhost:4566
 ```
 
 ## 📊 Monitoring

--- a/app/api/v1/laboratory.py
+++ b/app/api/v1/laboratory.py
@@ -1,11 +1,26 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
+from typing import Dict
 from sqlmodel import select, Session
 from app.core.db import get_session
 from app.models.laboratory import LabOrder, Sample
+from app.models.storage import StorageObject, SampleImage, SampleImageRendition
 from app.models.tenant import Tenant, Branch
 from app.models.patient import Patient
 from app.models.user import AppUser
-from app.schemas.laboratory import LabOrderCreate, LabOrderResponse, LabOrderDetailResponse, SampleCreate, SampleResponse
+from app.schemas.laboratory import (
+    LabOrderCreate,
+    LabOrderResponse,
+    LabOrderDetailResponse,
+    SampleCreate,
+    SampleResponse,
+    SampleImagesListResponse,
+    SampleImageInfo,
+    SampleImageUploadResponse,
+)
+from app.services.s3 import S3Service
+from app.services.image_processing import process_image_bytes
+from uuid import uuid4
+import os
 
 router = APIRouter(prefix="/laboratory")
 
@@ -156,3 +171,183 @@ def create_sample(sample_data: SampleCreate, session: Session = Depends(get_sess
         tenant_id=str(sample.tenant_id),
         branch_id=str(sample.branch_id)
     )
+
+
+@router.post("/samples/{sample_id}/images", response_model=SampleImageUploadResponse)
+def upload_sample_image(sample_id: str, file: UploadFile = File(...), session: Session = Depends(get_session)):
+    """Upload an image (regular or RAW) for a sample, store S3 keys and DB mapping.
+
+    Stores:
+    - RAW original (if applicable)
+    - processed JPEG
+    - thumbnail JPEG
+    """
+    sample = session.get(Sample, sample_id)
+    if not sample:
+        raise HTTPException(404, "Sample not found")
+
+    filename = file.filename or "upload"
+    data = file.file.read()
+
+    processed = process_image_bytes(filename, data)
+    is_raw = processed.original_bytes is not None
+
+    s3 = S3Service()
+    unique_id = uuid4().hex[:8]
+    base_name, ext = os.path.splitext(filename)
+
+    # Build S3 keys (tenant/branch/sample grouping)
+    base_prefix = f"samples/{sample.tenant_id}/{sample.branch_id}/{sample.id}"
+
+    # Upload processed and thumbnail
+    processed_key = f"{base_prefix}/processed/{base_name}_{unique_id}.jpg"
+    processed_info = s3.upload_bytes(
+        processed.processed_jpeg_bytes,
+        key=processed_key,
+        content_type="image/jpeg",
+        acl=None,
+    )
+
+    thumb_key = f"{base_prefix}/thumbnails/{base_name}_{unique_id}.jpg"
+    thumb_info = s3.upload_bytes(
+        processed.thumbnail_jpeg_bytes,
+        key=thumb_key,
+        content_type="image/jpeg",
+        acl=None,
+    )
+
+    # Create StorageObject rows
+    processed_storage = StorageObject(
+        provider="aws",
+        region=str(s3._session.region_name or "us-east-1"),
+        bucket=processed_info.bucket,
+        object_key=processed_info.key,
+        version_id=processed_info.version_id,
+        etag=processed_info.etag,
+        content_type="image/jpeg",
+        size_bytes=processed_info.size_bytes,
+    )
+    session.add(processed_storage)
+    session.flush()
+
+    thumb_storage = StorageObject(
+        provider="aws",
+        region=str(s3._session.region_name or "us-east-1"),
+        bucket=thumb_info.bucket,
+        object_key=thumb_info.key,
+        version_id=thumb_info.version_id,
+        etag=thumb_info.etag,
+        content_type="image/jpeg",
+        size_bytes=thumb_info.size_bytes,
+    )
+    session.add(thumb_storage)
+    session.flush()
+
+    # Link as SampleImage and renditions
+    sample_image = SampleImage(
+        tenant_id=sample.tenant_id,
+        branch_id=sample.branch_id,
+        sample_id=sample.id,
+        storage_id=processed_storage.id,
+        label=None,
+        is_primary=False,
+    )
+    session.add(sample_image)
+    session.flush()
+
+    rendition_thumb = SampleImageRendition(
+        sample_image_id=sample_image.id,
+        kind="thumbnail",
+        storage_id=thumb_storage.id,
+    )
+    session.add(rendition_thumb)
+
+    original_storage = None
+    if is_raw and processed.original_bytes:
+        raw_key = f"{base_prefix}/raw/{base_name}_{unique_id}{ext.lower()}"
+        raw_info = s3.upload_bytes(
+            processed.original_bytes,
+            key=raw_key,
+            content_type=file.content_type or "application/octet-stream",
+            acl=None,
+        )
+        original_storage = StorageObject(
+            provider="aws",
+            region=str(s3._session.region_name or "us-east-1"),
+            bucket=raw_info.bucket,
+            object_key=raw_info.key,
+            version_id=raw_info.version_id,
+            etag=raw_info.etag,
+            content_type=file.content_type,
+            size_bytes=raw_info.size_bytes,
+        )
+        session.add(original_storage)
+        session.flush()
+        rendition_original = SampleImageRendition(
+            sample_image_id=sample_image.id,
+            kind="original_raw",
+            storage_id=original_storage.id,
+        )
+        session.add(rendition_original)
+
+    session.commit()
+
+    urls: Dict[str, str] = {
+        "processed": s3.object_public_url(processed_key),
+        "thumbnail": s3.object_public_url(thumb_key),
+    }
+    if is_raw and original_storage is not None:
+        urls["raw"] = s3.object_public_url(original_storage.object_key)
+
+    return SampleImageUploadResponse(
+        message="Image uploaded successfully",
+        sample_image_id=str(sample_image.id),
+        filename=filename,
+        is_raw=is_raw,
+        file_size=len(data),
+        urls=urls,
+    )
+
+
+@router.get("/samples/{sample_id}/images", response_model=SampleImagesListResponse)
+def list_sample_images(sample_id: str, session: Session = Depends(get_session)):
+    """List images and their URLs for a sample, similar to file_mapping.json idea."""
+    sample = session.get(Sample, sample_id)
+    if not sample:
+        raise HTTPException(404, "Sample not found")
+
+    s3 = S3Service()
+
+    # Fetch images and renditions with simple selects
+    images = session.exec(
+        select(SampleImage).where(SampleImage.sample_id == sample.id)
+    ).all()
+
+    results = []
+    for img in images:
+        # main processed image
+        storage = session.get(StorageObject, img.storage_id)
+        urls: Dict[str, str] = {}
+        if storage:
+            urls["processed"] = s3.object_public_url(storage.object_key)
+
+        # renditions
+        renditions = session.exec(
+            select(SampleImageRendition).where(SampleImageRendition.sample_image_id == img.id)
+        ).all()
+        for r in renditions:
+            r_storage = session.get(StorageObject, r.storage_id)
+            if r_storage:
+                urls[r.kind] = s3.object_public_url(r_storage.object_key)
+
+        results.append(
+            SampleImageInfo(
+                id=str(img.id),
+                label=img.label,
+                is_primary=img.is_primary,
+                created_at=str(img.created_at),
+                urls=urls,
+            )
+        )
+
+    return SampleImagesListResponse(sample_id=str(sample.id), images=results)

--- a/app/api/v1/laboratory.py
+++ b/app/api/v1/laboratory.py
@@ -2,8 +2,8 @@ from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
 from typing import Dict
 from sqlmodel import select, Session
 from app.core.db import get_session
-from app.models.laboratory import LabOrder, Sample
-from app.models.storage import StorageObject, SampleImage, SampleImageRendition
+from app.models.laboratory import LabOrder, Sample, SampleImage
+from app.models.storage import StorageObject, SampleImageRendition
 from app.models.tenant import Tenant, Branch
 from app.models.patient import Patient
 from app.models.user import AppUser

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -7,6 +7,17 @@ class Settings(BaseSettings):
     jwt_secret: str
     jwt_expires_min: int = 480
 
+    # AWS S3 configuration
+    aws_access_key_id: str | None = None
+    aws_secret_access_key: str | None = None
+    aws_region: str | None = None
+    s3_bucket_name: str | None = None
+    s3_endpoint_url: str | None = None  # Optional for custom endpoints / localstack
+
+    # Media configuration
+    media_public_base_url: str | None = None  # Optional CDN/base URL for public access
+    media_presigned_expire_seconds: int = 3600
+
     class Config:
         env_file = ".env"
 

--- a/app/schemas/laboratory.py
+++ b/app/schemas/laboratory.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Optional
+from typing import Optional, List, Dict
 from datetime import datetime
 
 class LabOrderCreate(BaseModel):
@@ -53,3 +53,28 @@ class SampleResponse(BaseModel):
     order_id: str
     tenant_id: str
     branch_id: str
+
+
+class SampleImageInfo(BaseModel):
+    """Schema for a sample image with URLs to renditions."""
+    id: str
+    label: Optional[str] = None
+    is_primary: bool
+    created_at: str
+    urls: Dict[str, str]
+
+
+class SampleImagesListResponse(BaseModel):
+    """Schema for list of sample images."""
+    sample_id: str
+    images: List[SampleImageInfo]
+
+
+class SampleImageUploadResponse(BaseModel):
+    """Schema for upload image response, similar to experiments mapping."""
+    message: str
+    sample_image_id: str
+    filename: str
+    is_raw: bool
+    file_size: int
+    urls: Dict[str, str]

--- a/app/services/image_processing.py
+++ b/app/services/image_processing.py
@@ -50,17 +50,21 @@ def process_image_bytes(filename: str, data: bytes) -> ProcessedImage:
     is_raw = any(lower.endswith(ext) for ext in RAW_EXTENSIONS)
 
     if is_raw and rawpy is not None:
-        raw = rawpy.imread(BytesIO(data))  # type: ignore[attr-defined]
-        rgb = raw.postprocess(use_auto_wb=True, no_auto_bright=True)
-        pil = Image.fromarray(rgb)
-        pil = ImageOps.exif_transpose(pil).convert("RGB")
-        processed = _encode_jpeg(pil, quality=90)
-        thumb = _encode_jpeg(_make_thumbnail(pil), quality=85)
-        return ProcessedImage(
-            original_bytes=data,
-            processed_jpeg_bytes=processed,
-            thumbnail_jpeg_bytes=thumb,
-        )
+        try:
+            raw = rawpy.imread(BytesIO(data))  # type: ignore[attr-defined]
+            rgb = raw.postprocess(use_auto_wb=True, no_auto_bright=True)
+            pil = Image.fromarray(rgb)
+            pil = ImageOps.exif_transpose(pil).convert("RGB")
+            processed = _encode_jpeg(pil, quality=90)
+            thumb = _encode_jpeg(_make_thumbnail(pil), quality=85)
+            return ProcessedImage(
+                original_bytes=data,
+                processed_jpeg_bytes=processed,
+                thumbnail_jpeg_bytes=thumb,
+            )
+        except Exception:
+            # Fallback to regular image processing if RAW decoding fails
+            pass
 
     # Fallback for regular images
     pil = Image.open(BytesIO(data))

--- a/app/services/image_processing.py
+++ b/app/services/image_processing.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import BytesIO
+from typing import Optional, Tuple
+
+from PIL import Image, ImageOps
+
+try:
+    import rawpy  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    rawpy = None  # type: ignore
+
+
+RAW_EXTENSIONS = {
+    ".cr2", ".cr3", ".nef", ".nrw", ".arw", ".sr2", ".raf",
+    ".rw2", ".orf", ".pef", ".dng",
+}
+
+
+@dataclass
+class ProcessedImage:
+    """Holds in-memory image renditions to upload."""
+    original_bytes: Optional[bytes]
+    processed_jpeg_bytes: bytes
+    thumbnail_jpeg_bytes: bytes
+    content_type_processed: str = "image/jpeg"
+    content_type_thumbnail: str = "image/jpeg"
+
+
+def _encode_jpeg(pil_image: Image.Image, quality: int = 90) -> bytes:
+    buffer = BytesIO()
+    pil_image.save(buffer, format="JPEG", quality=quality, optimize=True)
+    return buffer.getvalue()
+
+
+def _make_thumbnail(pil_image: Image.Image, size: Tuple[int, int] = (512, 512)) -> Image.Image:
+    thumb = ImageOps.exif_transpose(pil_image.copy())
+    thumb.thumbnail(size, Image.LANCZOS)
+    return thumb
+
+
+def process_image_bytes(filename: str, data: bytes) -> ProcessedImage:
+    """Process an uploaded file and prepare processed and thumbnail renditions.
+
+    - If RAW (by extension) and rawpy available: decode to RGB then JPEG + thumbnail.
+    - If not RAW: open with Pillow, convert to RGB, JPEG + thumbnail.
+    """
+    lower = filename.lower()
+    is_raw = any(lower.endswith(ext) for ext in RAW_EXTENSIONS)
+
+    if is_raw and rawpy is not None:
+        raw = rawpy.imread(BytesIO(data))  # type: ignore[attr-defined]
+        rgb = raw.postprocess(use_auto_wb=True, no_auto_bright=True)
+        pil = Image.fromarray(rgb)
+        pil = ImageOps.exif_transpose(pil).convert("RGB")
+        processed = _encode_jpeg(pil, quality=90)
+        thumb = _encode_jpeg(_make_thumbnail(pil), quality=85)
+        return ProcessedImage(
+            original_bytes=data,
+            processed_jpeg_bytes=processed,
+            thumbnail_jpeg_bytes=thumb,
+        )
+
+    # Fallback for regular images
+    pil = Image.open(BytesIO(data))
+    pil = ImageOps.exif_transpose(pil).convert("RGB")
+    processed = _encode_jpeg(pil, quality=90)
+    thumb = _encode_jpeg(_make_thumbnail(pil), quality=85)
+    return ProcessedImage(
+        original_bytes=None,  # original not required for non-RAW
+        processed_jpeg_bytes=processed,
+        thumbnail_jpeg_bytes=thumb,
+    )
+
+

--- a/app/services/s3.py
+++ b/app/services/s3.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+import boto3
+from botocore.client import Config as BotoConfig
+from app.core.config import settings
+
+
+@dataclass
+class S3ObjectInfo:
+    """Information about an object stored in S3."""
+    bucket: str
+    key: str
+    size_bytes: Optional[int]
+    content_type: Optional[str]
+    etag: Optional[str]
+    version_id: Optional[str]
+
+
+class S3Service:
+    """Thin wrapper around boto3 for uploading and generating URLs."""
+
+    def __init__(self) -> None:
+        session_kwargs: dict[str, str] = {}
+        if settings.aws_access_key_id and settings.aws_secret_access_key:
+            session_kwargs["aws_access_key_id"] = settings.aws_access_key_id
+            session_kwargs["aws_secret_access_key"] = settings.aws_secret_access_key
+
+        self._session = boto3.session.Session(
+            region_name=settings.aws_region,
+            **session_kwargs,
+        )
+
+        client_kwargs: dict[str, object] = {
+            "config": BotoConfig(signature_version="s3v4"),
+        }
+        if settings.s3_endpoint_url:
+            client_kwargs["endpoint_url"] = settings.s3_endpoint_url
+
+        self._client = self._session.client("s3", **client_kwargs)
+
+    @property
+    def bucket(self) -> str:
+        if not settings.s3_bucket_name:
+            raise RuntimeError("S3 bucket name is not configured")
+        return settings.s3_bucket_name
+
+    def upload_bytes(
+        self,
+        data: bytes,
+        key: str,
+        content_type: Optional[str] = None,
+        acl: Optional[str] = None,
+    ) -> S3ObjectInfo:
+        extra_args: dict[str, str] = {}
+        if content_type:
+            extra_args["ContentType"] = content_type
+        if acl:
+            extra_args["ACL"] = acl
+
+        response = self._client.put_object(
+            Bucket=self.bucket,
+            Key=key,
+            Body=data,
+            **({"ContentType": content_type} if content_type else {}),
+            **({"ACL": acl} if acl else {}),
+        )
+
+        etag = response.get("ETag", None)
+        version_id = response.get("VersionId", None)
+
+        head = self._client.head_object(Bucket=self.bucket, Key=key)
+        size = int(head.get("ContentLength", 0))
+
+        return S3ObjectInfo(
+            bucket=self.bucket,
+            key=key,
+            size_bytes=size,
+            content_type=content_type,
+            etag=etag.strip('"') if isinstance(etag, str) else None,
+            version_id=version_id if isinstance(version_id, str) else None,
+        )
+
+    def generate_presigned_url(self, key: str, expires_in: Optional[int] = None) -> str:
+        expiry = expires_in if expires_in is not None else settings.media_presigned_expire_seconds
+        return self._client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": self.bucket, "Key": key},
+            ExpiresIn=expiry,
+        )
+
+    def object_public_url(self, key: str) -> str:
+        if settings.media_public_base_url:
+            base = settings.media_public_base_url.rstrip("/")
+            return f"{base}/{key}"
+        region = settings.aws_region or "us-east-1"
+        return f"https://{self.bucket}.s3.{region}.amazonaws.com/{key}"
+
+

--- a/app/services/s3.py
+++ b/app/services/s3.py
@@ -46,6 +46,14 @@ class S3Service:
             raise RuntimeError("S3 bucket name is not configured")
         return settings.s3_bucket_name
 
+    @property
+    def region(self) -> str:
+        """Public accessor for the configured AWS region.
+
+        Falls back to settings.aws_region and finally to 'mx-central-1'.
+        """
+        return (self._session.region_name or settings.aws_region or "mx-central-1")
+
     def upload_bytes(
         self,
         data: bytes,
@@ -94,7 +102,7 @@ class S3Service:
         if settings.media_public_base_url:
             base = settings.media_public_base_url.rstrip("/")
             return f"{base}/{key}"
-        region = settings.aws_region or "us-east-1"
+        region = settings.aws_region or "mx-central-1"
         return f"https://{self.bucket}.s3.{region}.amazonaws.com/{key}"
 
 

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -14,26 +14,40 @@ services:
   db-init:
     image: ghcr.io/celuma/celuma-backend:latest
     pull_policy: always
+    env_file: .env
     environment:
-      - APP_NAME=celuma
-      - ENV=dev
-      - DATABASE_URL=postgresql+psycopg2://postgres:postgres@db:5432/celumadb
-      - JWT_SECRET=secret
-      - JWT_EXPIRES_MIN=480
+      - APP_NAME=${APP_NAME:-celuma}
+      - ENV=${ENV:-dev}
+      - DATABASE_URL=${DATABASE_URL:-postgresql+psycopg2://postgres:postgres@db:5432/celumadb}
+      - JWT_SECRET=${JWT_SECRET}
+      - JWT_EXPIRES_MIN=${JWT_EXPIRES_MIN:-480}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_REGION=${AWS_REGION}
+      - S3_BUCKET_NAME=${S3_BUCKET_NAME}
+      - MEDIA_PUBLIC_BASE_URL=${MEDIA_PUBLIC_BASE_URL}
+      - MEDIA_PRESIGNED_EXPIRE_SECONDS=${MEDIA_PRESIGNED_EXPIRE_SECONDS:-3600}
+      - S3_ENDPOINT_URL=${S3_ENDPOINT_URL}
     command: bash init_db.sh
     restart: "no"
 
   api:
     image: ghcr.io/celuma/celuma-backend:latest
     pull_policy: always
+    env_file: .env
     environment:
-      - DATABASE_URL=postgresql://postgres:postgres@db:5432/celumadb
-      - JWT_SECRET=your-super-secret-jwt-key-change-this-in-production
-      - JWT_EXPIRES_MIN=480
-      - APP_NAME=celuma
-      - ENV=production
-      - DB_HOST=db
-      - DB_PORT=5432
+      - DATABASE_URL=${DATABASE_URL:-postgresql+psycopg2://postgres:postgres@db:5432/celumadb}
+      - JWT_SECRET=${JWT_SECRET}
+      - JWT_EXPIRES_MIN=${JWT_EXPIRES_MIN:-480}
+      - APP_NAME=${APP_NAME:-celuma}
+      - ENV=${ENV:-production}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_REGION=${AWS_REGION}
+      - S3_BUCKET_NAME=${S3_BUCKET_NAME}
+      - MEDIA_PUBLIC_BASE_URL=${MEDIA_PUBLIC_BASE_URL}
+      - MEDIA_PRESIGNED_EXPIRE_SECONDS=${MEDIA_PRESIGNED_EXPIRE_SECONDS:-3600}
+      - S3_ENDPOINT_URL=${S3_ENDPOINT_URL}
     ports: ["8000:8000"]
     depends_on:
       - db-init

--- a/docker-compose.remote-db.yml
+++ b/docker-compose.remote-db.yml
@@ -8,12 +8,20 @@ version: '3.8'
 services:
   db-init:
     image: ghcr.io/celuma/celuma-backend:latest
+    env_file: .env
     environment:
       - DATABASE_URL=${DATABASE_URL}
       - JWT_SECRET=${JWT_SECRET}
       - JWT_EXPIRES_MIN=${JWT_EXPIRES_MIN:-480}
       - APP_NAME=${APP_NAME:-celuma}
       - ENV=${ENV:-production}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_REGION=${AWS_REGION}
+      - S3_BUCKET_NAME=${S3_BUCKET_NAME}
+      - MEDIA_PUBLIC_BASE_URL=${MEDIA_PUBLIC_BASE_URL}
+      - MEDIA_PRESIGNED_EXPIRE_SECONDS=${MEDIA_PRESIGNED_EXPIRE_SECONDS:-3600}
+      - S3_ENDPOINT_URL=${S3_ENDPOINT_URL}
     command: bash init_db.sh
     restart: "no"
     networks:
@@ -21,12 +29,20 @@ services:
 
   api:
     image: ghcr.io/celuma/celuma-backend:latest
+    env_file: .env
     environment:
       - DATABASE_URL=${DATABASE_URL}
       - JWT_SECRET=${JWT_SECRET}
       - JWT_EXPIRES_MIN=${JWT_EXPIRES_MIN:-480}
       - APP_NAME=${APP_NAME:-celuma}
       - ENV=${ENV:-production}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_REGION=${AWS_REGION}
+      - S3_BUCKET_NAME=${S3_BUCKET_NAME}
+      - MEDIA_PUBLIC_BASE_URL=${MEDIA_PUBLIC_BASE_URL}
+      - MEDIA_PRESIGNED_EXPIRE_SECONDS=${MEDIA_PRESIGNED_EXPIRE_SECONDS:-3600}
+      - S3_ENDPOINT_URL=${S3_ENDPOINT_URL}
     ports: ["8000:8000"]
     depends_on:
       - db-init

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,19 @@ services:
     ports: ["8000:8000"]
     depends_on:
       - db-init
+    environment:
+      - DATABASE_URL=${DATABASE_URL:-postgresql+psycopg2://postgres:postgres@db:5432/celumadb}
+      - JWT_SECRET=${JWT_SECRET}
+      - JWT_EXPIRES_MIN=${JWT_EXPIRES_MIN:-480}
+      - APP_NAME=${APP_NAME:-celuma}
+      - ENV=${ENV:-dev}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_REGION=${AWS_REGION}
+      - S3_BUCKET_NAME=${S3_BUCKET_NAME}
+      - MEDIA_PUBLIC_BASE_URL=${MEDIA_PUBLIC_BASE_URL}
+      - MEDIA_PRESIGNED_EXPIRE_SECONDS=${MEDIA_PRESIGNED_EXPIRE_SECONDS:-3600}
+      - S3_ENDPOINT_URL=${S3_ENDPOINT_URL}
 
 volumes:
   pgdata:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,12 @@ passlib[bcrypt]==1.7.*
 python-multipart==0.0.*
 email-validator==2.2.*
 
+# AWS and Imaging
+boto3==1.34.*
+Pillow==10.*
+rawpy==0.25.*
+imageio==2.34.*
+
 # Testing
 pytest==8.4.1
 pytest-cov==6.2.1


### PR DESCRIPTION
This pull request introduces a complete image upload and management feature for laboratory samples, including backend API endpoints, S3 integration, image processing, and documentation. It enables users to upload RAW or regular images, automatically generates processed JPEGs and thumbnails, stores all renditions in S3, and exposes URLs for public or presigned access. The environment and deployment files are updated to support the necessary AWS and media configuration.

**Image Upload & Listing Feature:**

* Adds two new API endpoints to `app/api/v1/laboratory.py` for uploading sample images (`POST /samples/{sample_id}/images`) and listing images with their rendition URLs (`GET /samples/{sample_id}/images`). Handles both RAW and regular images, storing processed JPEGs, thumbnails, and RAW originals in S3, and maps them in the database. [[1]](diffhunk://#diff-47d124963a4ed14ece4faf55ff1f232c1f1229b67f97d7fafaa2be2957205df5L1-R23) [[2]](diffhunk://#diff-47d124963a4ed14ece4faf55ff1f232c1f1229b67f97d7fafaa2be2957205df5R174-R353)
* Introduces image processing logic in `app/services/image_processing.py` using Pillow and rawpy to handle RAW image decoding, JPEG conversion, and thumbnail generation.
* Implements S3 integration in `app/services/s3.py` for uploading files, generating public URLs, and presigned links, with configuration via environment variables.

**Schema & Configuration Updates:**

* Adds new response schemas for sample images and uploads in `app/schemas/laboratory.py`, and extends the configuration in `app/core/config.py` to support AWS S3 and media/CDN settings. [[1]](diffhunk://#diff-4aa46152ce7b82bea95dd7a2b1abe2883f9d8c9c1122feed7ea9a737296698beL2-R2) [[2]](diffhunk://#diff-4aa46152ce7b82bea95dd7a2b1abe2883f9d8c9c1122feed7ea9a737296698beR56-R80) [[3]](diffhunk://#diff-46319cab8aa9cca75fe586084b86c07f241657d02b324944bb7d300ce560039bR10-R20)

**Documentation & Deployment:**

* Updates documentation (`API_ENDPOINTS.md`, `API_EXAMPLES.md`) with details and examples for image upload and listing endpoints, including sample requests and responses. [[1]](diffhunk://#diff-2228edde3c2c869a4d2d631a9be8384086ef89e3c6634506331c78bac8451bf9R490-R539) [[2]](diffhunk://#diff-5b9a40ed86152c57c7909b5feaf67a4bd16e35ed420730e1ce8455cbb050b8b7R418-R461)
* Adds required AWS/media environment variables to deployment and environment files (`DEPLOYMENT_README.md`, `DEPLOYMENT_QUICKSTART.md`, `README.md`, `.env.example`, `docker-compose.ghcr.yml`) for proper configuration in local and production setups. [[1]](diffhunk://#diff-b7e6400a3ac7b8e2040b963cbe53e78973cb0d17979fd3e34070598be5d3b05aR205-R219) [[2]](diffhunk://#diff-de83afc6b766bec40072526334c79e58adf2089ddcacd7a0e215eb07de62c860R65-R73) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R271-R286) [[4]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR6-R15) [[5]](diffhunk://#diff-853304662c013625dcbd238912cdcc9d9d42985f4e95924ae7fcc81fe43c83c0R17-R50)