### PR TITLE
chore: update GHCR docker-compose

### DIFF
--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -13,6 +13,7 @@ services:
 
   db-init:
     image: ghcr.io/celuma/celuma-backend:latest
+    pull_policy: always
     environment:
       - APP_NAME=celuma
       - ENV=dev
@@ -24,6 +25,7 @@ services:
 
   api:
     image: ghcr.io/celuma/celuma-backend:latest
+    pull_policy: always
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@db:5432/celumadb
       - JWT_SECRET=your-super-secret-jwt-key-change-this-in-production


### PR DESCRIPTION
This pull request updates the `docker-compose.ghcr.yml` configuration to ensure that the latest backend image is always pulled for both the `db-init` and `api` services. This change helps prevent issues with stale images during local development and deployment.

Docker image update policy:

* Added `pull_policy: always` to the `db-init` service to ensure the most recent backend image is used.
* Added `pull_policy: always` to the `api` service for consistent image freshness.