### PR TITLE
docs: sync API docs with implementation

### DIFF
--- a/API_ENDPOINTS.md
+++ b/API_ENDPOINTS.md
@@ -388,9 +388,13 @@ The API is designed with JSON request bodies for all POST endpoints, providing:
   "patient_id": "patient-uuid-here",
   "order_code": "ORD001",
   "requested_by": "Dr. Smith",
-  "notes": "Complete blood count requested"
+  "notes": "Complete blood count requested",
+  "created_by": "user-uuid-here"
 }
 ```
+
+**Notes:**
+- `created_by` is optional and must be a UUID (user id) if provided.
 
 **Response:**
 ```json
@@ -550,9 +554,14 @@ The API is designed with JSON request bodies for all POST endpoints, providing:
   "order_id": "order-uuid-here",
   "title": "Blood Test Report",
   "diagnosis_text": "Normal blood count results",
-  "published_at": "2025-08-18T12:00:00Z"
+  "published_at": "2025-08-18T12:00:00Z",
+  "created_by": "user-uuid-here"
 }
 ```
+
+**Notes:**
+- `created_by` is optional and must be a UUID (user id) if provided.
+- `published_at` is optional ISO 8601 datetime.
 
 **Response:**
 ```json
@@ -613,6 +622,10 @@ The API is designed with JSON request bodies for all POST endpoints, providing:
   "authored_at": "2025-08-18T12:30:00Z"
 }
 ```
+
+**Notes:**
+- `html_storage_id` is optional; include it only if you have an HTML rendition.
+- `authored_by` and `authored_at` are optional; if omitted, `authored_at` defaults to server time.
 
 **Response:**
 ```json
@@ -794,12 +807,17 @@ All entities include these common fields:
 - `created_at`: Creation timestamp
 - `updated_at`: Last update timestamp
 
+### ID and Date Types
+- All `id` and `*_id` fields are UUID strings.
+- Date-time fields use ISO 8601 format (e.g., `2025-08-18T12:30:00Z`).
+- `created_at` and `updated_at` are server-generated and MUST NOT be sent in request bodies.
+
 ### Status Enums
-- **Order Status**: `RECEIVED`, `PROCESSING`, `COMPLETED`, `CANCELLED`
-- **Sample State**: `RECEIVED`, `PROCESSING`, `COMPLETED`, `DISCARDED`
-- **Report Status**: `DRAFT`, `REVIEW`, `PUBLISHED`, `ARCHIVED`
-- **Invoice Status**: `PENDING`, `PAID`, `OVERDUE`, `CANCELLED`
-- **User Role**: `admin`, `technician`, `doctor`, `receptionist`
+- **Order Status**: `RECEIVED`, `PROCESSING`, `DIAGNOSIS`, `REVIEW`, `RELEASED`, `CLOSED`, `CANCELLED`
+- **Sample State**: uses Order Status values for lifecycle: `RECEIVED`, `PROCESSING`, `DIAGNOSIS`, `REVIEW`, `RELEASED`, `CLOSED`, `CANCELLED`
+- **Report Status**: `DRAFT`, `IN_REVIEW`, `APPROVED`, `PUBLISHED`, `RETRACTED`
+- **Invoice Status**: `PENDING`, `PAID`, `FAILED`, `REFUNDED`, `PARTIAL`
+- **User Role**: `admin`, `pathologist`, `lab_tech`, `assistant`, `billing`, `viewer`
 
 ## 🔐 Authentication
 
@@ -810,7 +828,7 @@ Authorization: Bearer <jwt_token>
 ```
 
 ### Token Expiration
-JWT tokens expire after 24 hours. Use the logout endpoint to invalidate tokens before expiration.
+JWT tokens expire after 480 minutes (8 hours) by default. Use the logout endpoint to invalidate tokens before expiration.
 
 ### Token Blacklisting
 When users logout, their tokens are automatically blacklisted and cannot be used for subsequent requests.
@@ -885,4 +903,4 @@ response = requests.post(
 
 ---
 
-**Note: All POST endpoints use JSON request bodies for optimal data handling, validation, and consistent API design.**
+**Note: All POST endpoints use JSON request bodies for optimal data handling, validation, and consistent API design, except the image upload endpoint which uses multipart/form-data.**

--- a/API_EXAMPLES.md
+++ b/API_EXAMPLES.md
@@ -4,7 +4,7 @@ This document provides comprehensive examples of how to use the Celuma API with 
 
 ## 🚀 JSON-First API Design
 
-**All POST endpoints use JSON request bodies for optimal data handling and validation.**
+**All POST endpoints use JSON request bodies for optimal data handling and validation (except the image upload endpoint which uses multipart/form-data).**
 
 ### Benefits of JSON Payloads
 - ✅ **Excellent Data Validation**: Pydantic schemas provide automatic validation
@@ -353,7 +353,8 @@ curl -X POST "http://localhost:8000/api/v1/laboratory/orders/" \
     "patient_id": "patient-uuid-here",
     "order_code": "ORD001",
     "requested_by": "Dr. Smith",
-    "notes": "Complete blood count requested"
+    "notes": "Complete blood count requested",
+    "created_by": "user-uuid-here"
   }'
 ```
 
@@ -367,7 +368,8 @@ response = requests.post(
         "patient_id": patient_id,
         "order_code": "ORD001",
         "requested_by": "Dr. Smith",
-        "notes": "Complete blood count requested"
+        "notes": "Complete blood count requested",
+        "created_by": user_id
     }
 )
 
@@ -418,7 +420,6 @@ if response.status_code == 200:
 ### Upload Sample Image (multipart/form-data)
 ```bash
 curl -X POST "http://localhost:8000/api/v1/laboratory/samples/SAMPLE_UUID/images" \
-  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
   -F "file=@/path/to/image.dng"
 ```
 
@@ -451,7 +452,6 @@ curl "http://localhost:8000/api/v1/laboratory/samples/SAMPLE_UUID/images" \
 ```python
 resp = requests.get(
     f"http://localhost:8000/api/v1/laboratory/samples/{sample_id}/images",
-    headers={"Authorization": f"Bearer {access_token}"},
 )
 resp.raise_for_status()
 images = resp.json()["images"]
@@ -471,7 +471,8 @@ curl -X POST "http://localhost:8000/api/v1/reports/" \
     "order_id": "order-uuid-here",
     "title": "Blood Test Report",
     "diagnosis_text": "Normal blood count results",
-    "published_at": "2025-08-18T12:00:00Z"
+    "published_at": "2025-08-18T12:00:00Z",
+    "created_by": "user-uuid-here"
   }'
 ```
 
@@ -485,7 +486,8 @@ response = requests.post(
         "order_id": order_id,
         "title": "Blood Test Report",
         "diagnosis_text": "Normal blood count results",
-        "published_at": "2025-08-18T12:00:00Z"
+        "published_at": "2025-08-18T12:00:00Z",
+        "created_by": user_id
     }
 )
 


### PR DESCRIPTION
This pull request updates the API documentation and example usage to clarify data formats, add optional user attribution fields, and refine status enums for greater consistency and clarity. The changes also specify an exception for the image upload endpoint's request format and update authentication details.

**API request/response documentation improvements:**

* Added `created_by` as an optional UUID field to POST request bodies for orders and reports, with explanatory notes clarifying its usage. [[1]](diffhunk://#diff-2228edde3c2c869a4d2d631a9be8384086ef89e3c6634506331c78bac8451bf9L391-R398) [[2]](diffhunk://#diff-2228edde3c2c869a4d2d631a9be8384086ef89e3c6634506331c78bac8451bf9L553-R565)
* Added notes about optional fields (`html_storage_id`, `authored_by`, `authored_at`) in sample report requests, specifying default behaviors and when to include them.
* Clarified that all `id` and `*_id` fields are UUID strings, date-time fields use ISO 8601 format, and `created_at`/`updated_at` are server-generated and must not be sent in requests.

**Status enums and user roles updates:**

* Expanded and refined status enums for orders, samples, reports, invoices, and user roles to better reflect lifecycle and team roles.

**Authentication and API format clarifications:**

* Updated JWT token expiration to 480 minutes (8 hours) and clarified token blacklisting behavior.
* Specified that all POST endpoints use JSON request bodies except for the image upload endpoint, which uses multipart/form-data. [[1]](diffhunk://#diff-2228edde3c2c869a4d2d631a9be8384086ef89e3c6634506331c78bac8451bf9L888-R906) [[2]](diffhunk://#diff-5b9a40ed86152c57c7909b5feaf67a4bd16e35ed420730e1ce8455cbb050b8b7L7-R7)

**Example updates for new fields and formats:**

* Updated example requests in `API_EXAMPLES.md` to include the new `created_by` field for orders and reports, and clarified the image upload endpoint's format. [[1]](diffhunk://#diff-5b9a40ed86152c57c7909b5feaf67a4bd16e35ed420730e1ce8455cbb050b8b7L356-R357) [[2]](diffhunk://#diff-5b9a40ed86152c57c7909b5feaf67a4bd16e35ed420730e1ce8455cbb050b8b7L370-R372) [[3]](diffhunk://#diff-5b9a40ed86152c57c7909b5feaf67a4bd16e35ed420730e1ce8455cbb050b8b7L474-R475) [[4]](diffhunk://#diff-5b9a40ed86152c57c7909b5feaf67a4bd16e35ed420730e1ce8455cbb050b8b7L488-R490)
* Minor corrections to example code for image upload and retrieval to match updated documentation. [[1]](diffhunk://#diff-5b9a40ed86152c57c7909b5feaf67a4bd16e35ed420730e1ce8455cbb050b8b7L421) [[2]](diffhunk://#diff-5b9a40ed86152c57c7909b5feaf67a4bd16e35ed420730e1ce8455cbb050b8b7L454)