### PR TITLE
feat: add PUT /auth/me for profile and password update

### DIFF
--- a/API_ENDPOINTS.md
+++ b/API_ENDPOINTS.md
@@ -145,6 +145,39 @@ The API is designed with JSON request bodies for all POST endpoints, providing:
 - `username` field will be `null` if the user doesn't have a username set
 - All other user information is always included
 
+### PUT /api/v1/auth/me
+**Update current user profile and/or password**
+
+**Headers:** `Authorization: Bearer <token>`
+
+**Request Body:**
+```json
+{
+  "full_name": "New Name",
+  "username": "new-username",
+  "email": "new.email@example.com",
+  "current_password": "oldpass",
+  "new_password": "newpass123"
+}
+```
+
+**Response:**
+```json
+{
+  "id": "user-uuid",
+  "email": "new.email@example.com",
+  "username": "new-username",
+  "full_name": "New Name",
+  "role": "admin",
+  "tenant_id": "tenant-uuid-here"
+}
+```
+
+**Notes:**
+- To change the password, you must provide both `current_password` and `new_password`. The current password must match the existing one.
+- `username` and `email` must be unique within the tenant.
+- All fields are optional; only the provided fields will be updated.
+
 ## 🏢 Tenant Management
 
 ### POST /api/v1/tenants/

--- a/API_EXAMPLES.md
+++ b/API_EXAMPLES.md
@@ -148,6 +148,61 @@ if response.status_code == 200:
         print("No username set")
 ```
 
+### Update Profile (PUT)
+```bash
+# Update profile details (name, username, email)
+curl -X PUT "http://localhost:8000/api/v1/auth/me" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "full_name": "New Name",
+    "username": "new-username",
+    "email": "new.email@example.com"
+  }'
+
+# Change password (requires current_password and new_password)
+curl -X PUT "http://localhost:8000/api/v1/auth/me" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "current_password": "oldpass",
+    "new_password": "newpass123"
+  }'
+```
+
+**Python Example:**
+```python
+import requests
+
+headers = {"Authorization": f"Bearer {access_token}", "Content-Type": "application/json"}
+
+# Update profile fields
+resp = requests.put(
+    "http://localhost:8000/api/v1/auth/me",
+    headers=headers,
+    json={
+        "full_name": "New Name",
+        "username": "new-username",
+        "email": "new.email@example.com",
+    },
+)
+resp.raise_for_status()
+updated = resp.json()
+print("Updated name:", updated["full_name"])  # New Name
+
+# Change password
+pwd_resp = requests.put(
+    "http://localhost:8000/api/v1/auth/me",
+    headers=headers,
+    json={
+        "current_password": "oldpass",
+        "new_password": "newpass123",
+    },
+)
+pwd_resp.raise_for_status()
+print("Password changed successfully")
+```
+
 ### User Logout
 ```bash
 curl -X POST "http://localhost:8000/api/v1/auth/logout" \

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -52,3 +52,11 @@ class UserProfile(BaseModel):
     full_name: str
     role: str
     tenant_id: str
+
+class UserProfileUpdate(BaseModel):
+    """Schema for updating user profile and password"""
+    full_name: Optional[str] = None
+    username: Optional[str] = None
+    email: Optional[EmailStr] = None
+    current_password: Optional[str] = None
+    new_password: Optional[str] = None


### PR DESCRIPTION
This pull request introduces a new API endpoint that allows authenticated users to update their own profile information and password. The changes include backend implementation, schema definition, and documentation with usage examples.

**User Profile Update Feature:**

*Backend Implementation:*
- Added a new `PUT /api/v1/auth/me` endpoint in `app/api/v1/auth.py` that allows users to update their `full_name`, `username`, `email`, and/or change their password. The endpoint includes validation to ensure that `username` and `email` are unique within the tenant, and requires the correct current password to change the password.

*Schema Updates:*
- Introduced a new `UserProfileUpdate` schema in `app/schemas/auth.py` to define the allowed fields for profile and password updates. All fields are optional, and password updates require both `current_password` and `new_password`. [[1]](diffhunk://#diff-19ffc359555885ade92ec94b91184f057d6cd7934407de87a4ca663b5d00eab4R55-R62) [[2]](diffhunk://#diff-1eb6e637bb9d31d728fe2a5bb5d9644dbd1c42182c504a5474c45af433a6e23fR19)

*Documentation & Examples:*
- Updated `API_ENDPOINTS.md` to document the new `PUT /api/v1/auth/me` endpoint, including request/response formats and validation rules.
- Added example usage for the new endpoint in `API_EXAMPLES.md`, including both `curl` and Python code samples for updating profile details and changing the password.