### PR TITLE
feat: add unified registration endpoint and docs

### DIFF
--- a/API_ENDPOINTS.md
+++ b/API_ENDPOINTS.md
@@ -37,11 +37,6 @@ The API is designed with JSON request bodies for all POST endpoints, providing:
 }
 ```
 
-**Notes:**
-- `username` field is **optional** - users can register with or without a username
-- If `username` is provided, it must be unique within the tenant
-- `email` is always required and must be unique within the tenant
-
 **Response:**
 ```json
 {
@@ -52,6 +47,57 @@ The API is designed with JSON request bodies for all POST endpoints, providing:
   "role": "admin"
 }
 ```
+
+**Notes:**
+- `username` field is **optional** - users can register with or without a username
+- If `username` is provided, it must be unique within the tenant
+- `email` is always required and must be unique within the tenant
+
+### POST /api/v1/auth/register/unified
+**Unified registration: create tenant, branch and admin user**
+
+Request body:
+
+```json
+{
+  "tenant": {
+    "name": "Acme Labs",
+    "legal_name": "Acme Laboratories S.A. de C.V.",
+    "tax_id": "ACM010101ABC"
+  },
+  "branch": {
+    "code": "HQ",
+    "name": "Headquarters",
+    "timezone": "America/Mexico_City",
+    "address_line1": "Av. Siempre Viva 123",
+    "city": "CDMX",
+    "state": "CDMX",
+    "postal_code": "01234",
+    "country": "MX"
+  },
+  "admin_user": {
+    "email": "admin@acme.com",
+    "username": "admin",
+    "password": "Secret123!",
+    "full_name": "Admin User"
+  }
+}
+```
+
+Response body:
+
+```json
+{
+  "tenant_id": "...",
+  "branch_id": "...",
+  "user_id": "..."
+}
+```
+
+**Notes:**
+- The operation is atomic. If any step fails, nothing is created.
+- The created user has role "admin" and is linked to the created branch.
+- `branch.code` must be unique per tenant.
 
 ### POST /api/v1/auth/login
 **Authenticate a user and return an access token. Supports username or email.**

--- a/API_EXAMPLES.md
+++ b/API_EXAMPLES.md
@@ -15,6 +15,82 @@ This document provides comprehensive examples of how to use the Celuma API with 
 
 ## 🔐 Authentication
 
+### Unified Registration (tenant + branch + admin)
+```bash
+curl -X POST "http://localhost:8000/api/v1/auth/register/unified" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tenant": {
+      "name": "Acme Labs",
+      "legal_name": "Acme Laboratories S.A. de C.V.",
+      "tax_id": "ACM010101ABC"
+    },
+    "branch": {
+      "code": "HQ",
+      "name": "Headquarters",
+      "timezone": "America/Mexico_City",
+      "address_line1": "Av. Siempre Viva 123",
+      "city": "CDMX",
+      "state": "CDMX",
+      "postal_code": "01234",
+      "country": "MX"
+    },
+    "admin_user": {
+      "email": "admin@acme.com",
+      "username": "admin",
+      "password": "Secret123!",
+      "full_name": "Admin User"
+    }
+  }'
+```
+
+**Notes:**
+- Operation is atomic; on failure nothing is created.
+- The created user has role `admin` and is linked to the created branch.
+- `branch.code` must be unique per tenant.
+
+**Python Example:**
+```python
+import requests
+
+payload = {
+    "tenant": {
+        "name": "Acme Labs",
+        "legal_name": "Acme Laboratories S.A. de C.V.",
+        "tax_id": "ACM010101ABC",
+    },
+    "branch": {
+        "code": "HQ",
+        "name": "Headquarters",
+        "timezone": "America/Mexico_City",
+        "address_line1": "Av. Siempre Viva 123",
+        "city": "CDMX",
+        "state": "CDMX",
+        "postal_code": "01234",
+        "country": "MX",
+    },
+    "admin_user": {
+        "email": "admin@acme.com",
+        "username": "admin",
+        "password": "Secret123!",
+        "full_name": "Admin User",
+    },
+}
+
+resp = requests.post(
+    "http://localhost:8000/api/v1/auth/register/unified",
+    json=payload,
+)
+resp.raise_for_status()
+data = resp.json()
+tenant_id = data["tenant_id"]
+branch_id = data["branch_id"]
+user_id = data["user_id"]
+print("Tenant:", tenant_id)
+print("Branch:", branch_id)
+print("Admin user:", user_id)
+```
+
 ### User Registration
 ```bash
 curl -X POST "http://localhost:8000/api/v1/auth/register" \

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -3,8 +3,9 @@ from fastapi.security import HTTPBearer
 from jose import jwt, JWTError
 from sqlmodel import select, Session
 from app.core.db import get_session
-from app.models.user import AppUser, BlacklistedToken
-from app.models.tenant import Tenant
+from app.models.user import AppUser, BlacklistedToken, UserBranch
+from app.models.tenant import Tenant, Branch
+from app.models.enums import UserRole
 from app.core.security import hash_password, verify_password, create_jwt, decode_jwt
 from app.core.config import settings
 from app.schemas.auth import (
@@ -17,6 +18,8 @@ from app.schemas.auth import (
     LoginTenantSelectionResponse,
     TenantOption,
     UserProfileUpdate,
+    RegistrationRequest,
+    RegistrationResponse,
 )
 from datetime import datetime
 from typing import Union
@@ -226,3 +229,85 @@ def update_me(
         role=user.role,
         tenant_id=str(user.tenant_id),
     )
+
+
+@router.post("/register/unified", response_model=RegistrationResponse)
+def unified_registration(payload: RegistrationRequest, session: Session = Depends(get_session)):
+    """Create tenant, default branch, and admin user in a single atomic operation."""
+    try:
+        # Start explicit transaction for atomicity
+        with session.begin():
+            # 1) Create tenant
+            tenant = Tenant(
+                name=payload.tenant.name,
+                legal_name=payload.tenant.legal_name,
+                tax_id=payload.tenant.tax_id,
+            )
+            session.add(tenant)
+            session.flush()  # ensure tenant.id is available
+
+            # 2) Create branch (ensure code uniqueness within tenant)
+            existing_branch = session.exec(
+                select(Branch).where(Branch.tenant_id == tenant.id, Branch.code == payload.branch.code)
+            ).first()
+            if existing_branch:
+                raise HTTPException(400, "Branch code already exists for this tenant")
+
+            branch = Branch(
+                tenant_id=tenant.id,
+                code=payload.branch.code,
+                name=payload.branch.name,
+                timezone=payload.branch.timezone,
+                address_line1=payload.branch.address_line1,
+                address_line2=payload.branch.address_line2,
+                city=payload.branch.city,
+                state=payload.branch.state,
+                postal_code=payload.branch.postal_code,
+                country=payload.branch.country,
+            )
+            session.add(branch)
+            session.flush()
+
+            # 3) Create admin user (ensure email/username uniqueness within tenant)
+            existing_email = session.exec(
+                select(AppUser).where(AppUser.email == payload.admin_user.email, AppUser.tenant_id == tenant.id)
+            ).first()
+            if existing_email:
+                raise HTTPException(400, "Email already registered for this tenant")
+
+            if payload.admin_user.username:
+                existing_username = session.exec(
+                    select(AppUser).where(
+                        AppUser.username == payload.admin_user.username,
+                        AppUser.tenant_id == tenant.id,
+                    )
+                ).first()
+                if existing_username:
+                    raise HTTPException(400, "Username already registered for this tenant")
+
+            user = AppUser(
+                tenant_id=tenant.id,
+                email=payload.admin_user.email,
+                username=payload.admin_user.username,
+                full_name=payload.admin_user.full_name,
+                role=UserRole.ADMIN,
+                hashed_password=hash_password(payload.admin_user.password),
+            )
+            session.add(user)
+            session.flush()
+
+            # 4) Associate user with branch
+            session.add(UserBranch(user_id=user.id, branch_id=branch.id))
+
+        # After context, transaction committed
+        return RegistrationResponse(
+            tenant_id=str(tenant.id),
+            branch_id=str(branch.id),
+            user_id=str(user.id),
+        )
+    except HTTPException:
+        # Propagate known errors
+        raise
+    except Exception as e:
+        session.rollback()
+        raise HTTPException(500, f"Registration failed: {str(e)}")

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -60,3 +60,46 @@ class UserProfileUpdate(BaseModel):
     email: Optional[EmailStr] = None
     current_password: Optional[str] = None
     new_password: Optional[str] = None
+
+
+class RegistrationTenant(BaseModel):
+    """Payload section for creating the tenant during unified registration"""
+    name: str
+    legal_name: Optional[str] = None
+    tax_id: Optional[str] = None
+
+
+class RegistrationBranch(BaseModel):
+    """Payload section for creating the default branch during unified registration"""
+    code: str
+    name: str
+    timezone: str = "America/Mexico_City"
+    address_line1: Optional[str] = None
+    address_line2: Optional[str] = None
+    city: Optional[str] = None
+    state: Optional[str] = None
+    postal_code: Optional[str] = None
+    country: str = "MX"
+
+
+class RegistrationAdminUser(BaseModel):
+    """Payload section for creating the initial admin user during unified registration"""
+    email: EmailStr
+    username: Optional[str] = None
+    password: str
+    full_name: str
+    # Role will always be admin for initial registration
+
+
+class RegistrationRequest(BaseModel):
+    """Unified registration request to create tenant, branch and admin user in one shot"""
+    tenant: RegistrationTenant
+    branch: RegistrationBranch
+    admin_user: RegistrationAdminUser
+
+
+class RegistrationResponse(BaseModel):
+    """Unified registration response with created entities identifiers"""
+    tenant_id: str
+    branch_id: str
+    user_id: str


### PR DESCRIPTION
This pull request introduces a unified registration API endpoint that allows clients to create a tenant, a default branch, and an admin user in a single atomic operation. It includes backend implementation, request/response schema definitions, and comprehensive documentation and usage examples.

**Unified Registration Endpoint Implementation:**

* Added a new POST endpoint `/api/v1/auth/register/unified` in `app/api/v1/auth.py` that atomically creates a tenant, a branch, and an admin user, ensuring all-or-nothing behavior. The endpoint checks for uniqueness of branch code, email, and username within the tenant, and associates the created admin user with the branch.
* Defined new Pydantic models in `app/schemas/auth.py` for the unified registration request and response structure, including `RegistrationTenant`, `RegistrationBranch`, `RegistrationAdminUser`, `RegistrationRequest`, and `RegistrationResponse`.

**Documentation and Usage Examples:**

* Updated `API_ENDPOINTS.md` to document the new `/api/v1/auth/register/unified` endpoint, including request/response examples and important notes about atomicity and uniqueness constraints.
* Added example usage for the unified registration endpoint in `API_EXAMPLES.md`, including both a `curl` command and a Python script.

**Codebase Adjustments:**

* Imported new models and schemas required for the unified registration flow in `app/api/v1/auth.py`. [[1]](diffhunk://#diff-1eb6e637bb9d31d728fe2a5bb5d9644dbd1c42182c504a5474c45af433a6e23fL6-R8) [[2]](diffhunk://#diff-1eb6e637bb9d31d728fe2a5bb5d9644dbd1c42182c504a5474c45af433a6e23fR21-R22)

**Documentation Cleanup:**

* Moved and reformatted the notes section in `API_ENDPOINTS.md` for clarity and consistency.