### PR TITLE
feat: add unified order+samples and patient cases/orders endpoints

### DIFF
--- a/API_ENDPOINTS.md
+++ b/API_ENDPOINTS.md
@@ -527,6 +527,120 @@ Response body:
 
 ### POST /api/v1/laboratory/samples/
 **Create a new sample**
+### POST /api/v1/laboratory/orders/unified
+**Create a laboratory order and multiple samples in one operation**
+
+**Request Body:**
+```json
+{
+  "tenant_id": "tenant-uuid-here",
+  "branch_id": "branch-uuid-here",
+  "patient_id": "patient-uuid-here",
+  "order_code": "ORD001",
+  "requested_by": "Dr. Smith",
+  "notes": "Complete blood count requested",
+  "created_by": "user-uuid-here",
+  "samples": [
+    {
+      "sample_code": "SAMP001",
+      "type": "SANGRE",
+      "notes": "",
+      "collected_at": "2025-08-18T10:00:00Z",
+      "received_at": "2025-08-18T11:00:00Z"
+    },
+    {
+      "sample_code": "SAMP002",
+      "type": "TEJIDO"
+    }
+  ]
+}
+```
+
+**Response:**
+```json
+{
+  "order": {
+    "id": "order-uuid",
+    "order_code": "ORD001",
+    "status": "RECEIVED",
+    "patient_id": "patient-uuid-here",
+    "tenant_id": "tenant-uuid-here",
+    "branch_id": "branch-uuid-here"
+  },
+  "samples": [
+    {
+      "id": "sample-uuid-1",
+      "sample_code": "SAMP001",
+      "type": "SANGRE",
+      "state": "RECEIVED",
+      "order_id": "order-uuid",
+      "tenant_id": "tenant-uuid-here",
+      "branch_id": "branch-uuid-here"
+    },
+    {
+      "id": "sample-uuid-2",
+      "sample_code": "SAMP002",
+      "type": "TEJIDO",
+      "state": "RECEIVED",
+      "order_id": "order-uuid",
+      "tenant_id": "tenant-uuid-here",
+      "branch_id": "branch-uuid-here"
+    }
+  ]
+}
+```
+
+**Errors:**
+- 400 if `order_code` already exists for the branch, a `sample_code` is duplicated in the request, or already exists in the order
+- 404 if tenant, branch, or patient not found
+
+---
+
+### GET /api/v1/laboratory/orders/{order_id}/full
+**Get complete order details including patient and samples**
+
+**Response:**
+```json
+{
+  "order": {
+    "id": "order-uuid",
+    "order_code": "ORD001",
+    "status": "RECEIVED",
+    "patient_id": "patient-uuid",
+    "tenant_id": "tenant-uuid",
+    "branch_id": "branch-uuid",
+    "requested_by": "Dr. Smith",
+    "notes": "...",
+    "billed_lock": false
+  },
+  "patient": {
+    "id": "patient-uuid",
+    "patient_code": "P001",
+    "first_name": "John",
+    "last_name": "Doe",
+    "dob": "1990-01-01",
+    "sex": "M",
+    "phone": "555-1234",
+    "email": "john.doe@example.com",
+    "tenant_id": "tenant-uuid",
+    "branch_id": "branch-uuid"
+  },
+  "samples": [
+    {
+      "id": "sample-uuid",
+      "sample_code": "SAMP001",
+      "type": "SANGRE",
+      "state": "RECEIVED",
+      "order_id": "order-uuid",
+      "tenant_id": "tenant-uuid",
+      "branch_id": "branch-uuid"
+    }
+  ]
+}
+```
+
+**Errors:**
+- 404 if order or patient is not found
 
 **Request Body:**
 ```json

--- a/API_ENDPOINTS.md
+++ b/API_ENDPOINTS.md
@@ -642,6 +642,81 @@ Response body:
 **Errors:**
 - 404 if order or patient is not found
 
+### GET /api/v1/laboratory/patients/{patient_id}/orders
+**List all orders for a given patient (summary)**
+
+**Response:**
+```json
+{
+  "patient_id": "patient-uuid",
+  "orders": [
+    {
+      "id": "order-uuid",
+      "order_code": "ORD001",
+      "status": "RECEIVED",
+      "tenant_id": "tenant-uuid",
+      "branch_id": "branch-uuid",
+      "patient_id": "patient-uuid",
+      "requested_by": "Dr. Smith",
+      "notes": "...",
+      "created_at": "2025-08-18T10:00:00Z",
+      "sample_count": 2,
+      "has_report": true
+    }
+  ]
+}
+```
+
+**Errors:**
+- 404 if patient not found
+
+### GET /api/v1/laboratory/patients/{patient_id}/cases
+**List complete cases for a given patient (order + samples + report meta)**
+
+**Response:**
+```json
+{
+  "patient_id": "patient-uuid",
+  "cases": [
+    {
+      "order": {
+        "id": "order-uuid",
+        "order_code": "ORD001",
+        "status": "RECEIVED",
+        "patient_id": "patient-uuid",
+        "tenant_id": "tenant-uuid",
+        "branch_id": "branch-uuid",
+        "requested_by": "Dr. Smith",
+        "notes": "...",
+        "billed_lock": false
+      },
+      "samples": [
+        {
+          "id": "sample-uuid",
+          "sample_code": "SAMP001",
+          "type": "SANGRE",
+          "state": "RECEIVED",
+          "order_id": "order-uuid",
+          "tenant_id": "tenant-uuid",
+          "branch_id": "branch-uuid"
+        }
+      ],
+      "report": {
+        "id": "report-uuid",
+        "status": "DRAFT",
+        "title": "Blood Test Report",
+        "published_at": null,
+        "version_no": 2,
+        "has_pdf": true
+      }
+    }
+  ]
+}
+```
+
+**Errors:**
+- 404 if patient not found
+
 **Request Body:**
 ```json
 {

--- a/API_ENDPOINTS.md
+++ b/API_ENDPOINTS.md
@@ -422,18 +422,24 @@ Response body:
 ```
 
 ### GET /api/v1/patients/
-**List all patients**
+**List all patients (full profile)**
+
+Returns a list of full patient profiles (`PatientFullResponse`).
 
 **Response:**
 ```json
 [
   {
     "id": "patient-uuid",
+    "tenant_id": "tenant-uuid-here",
+    "branch_id": "branch-uuid-here",
     "patient_code": "P001",
     "first_name": "John",
     "last_name": "Doe",
-    "tenant_id": "tenant-uuid-here",
-    "branch_id": "branch-uuid-here"
+    "dob": "1990-01-01",
+    "sex": "M",
+    "phone": "555-1234",
+    "email": "john.doe@example.com"
   }
 ]
 ```
@@ -597,7 +603,7 @@ Response body:
 ---
 
 ### GET /api/v1/laboratory/orders/{order_id}/full
-**Get complete order details including patient and samples**
+**Get complete order details including patient (full) and samples**
 
 **Response:**
 ```json
@@ -615,15 +621,15 @@ Response body:
   },
   "patient": {
     "id": "patient-uuid",
+    "tenant_id": "tenant-uuid",
+    "branch_id": "branch-uuid",
     "patient_code": "P001",
     "first_name": "John",
     "last_name": "Doe",
     "dob": "1990-01-01",
     "sex": "M",
     "phone": "555-1234",
-    "email": "john.doe@example.com",
-    "tenant_id": "tenant-uuid",
-    "branch_id": "branch-uuid"
+    "email": "john.doe@example.com"
   },
   "samples": [
     {
@@ -643,12 +649,23 @@ Response body:
 - 404 if order or patient is not found
 
 ### GET /api/v1/laboratory/patients/{patient_id}/orders
-**List all orders for a given patient (summary)**
+**List all orders for a given patient (summary) and return patient (full)**
 
 **Response:**
 ```json
 {
-  "patient_id": "patient-uuid",
+  "patient": {
+    "id": "patient-uuid",
+    "tenant_id": "tenant-uuid",
+    "branch_id": "branch-uuid",
+    "patient_code": "P001",
+    "first_name": "John",
+    "last_name": "Doe",
+    "dob": "1990-01-01",
+    "sex": "M",
+    "phone": "555-1234",
+    "email": "john.doe@example.com"
+  },
   "orders": [
     {
       "id": "order-uuid",
@@ -671,11 +688,23 @@ Response body:
 - 404 if patient not found
 
 ### GET /api/v1/laboratory/patients/{patient_id}/cases
-**List complete cases for a given patient (order + samples + report meta)**
+**List complete cases for a given patient (order + samples + report meta) and return patient (full)**
 
 **Response:**
 ```json
 {
+  "patient": {
+    "id": "patient-uuid",
+    "tenant_id": "tenant-uuid",
+    "branch_id": "branch-uuid",
+    "patient_code": "P001",
+    "first_name": "John",
+    "last_name": "Doe",
+    "dob": "1990-01-01",
+    "sex": "M",
+    "phone": "555-1234",
+    "email": "john.doe@example.com"
+  },
   "patient_id": "patient-uuid",
   "cases": [
     {

--- a/API_ENDPOINTS.md
+++ b/API_ENDPOINTS.md
@@ -497,20 +497,29 @@ Returns a list of full patient profiles (`PatientFullResponse`).
 ```
 
 ### GET /api/v1/laboratory/orders/
-**List all laboratory orders**
+**List all laboratory orders (enriched)**
+
+Returns `orders` array with enriched `branch` and `patient` objects and summary fields.
 
 **Response:**
 ```json
-[
-  {
-    "id": "order-uuid",
-    "order_code": "ORD001",
-    "status": "RECEIVED",
-    "patient_id": "patient-uuid-here",
-    "tenant_id": "tenant-uuid-here",
-    "branch_id": "branch-uuid-here"
-  }
-]
+{
+  "orders": [
+    {
+      "id": "order-uuid",
+      "order_code": "ORD001",
+      "status": "RECEIVED",
+      "tenant_id": "tenant-uuid",
+      "branch": { "id": "branch-uuid", "name": "Main Branch", "code": "MAIN" },
+      "patient": { "id": "patient-uuid", "full_name": "John Doe", "patient_code": "P001" },
+      "requested_by": "Dr. Smith",
+      "notes": "...",
+      "created_at": "2025-08-18T10:00:00Z",
+      "sample_count": 2,
+      "has_report": true
+    }
+  ]
+}
 ```
 
 ### GET /api/v1/laboratory/orders/{order_id}
@@ -774,21 +783,45 @@ Returns a list of full patient profiles (`PatientFullResponse`).
 ```
 
 ### GET /api/v1/laboratory/samples/
-**List all samples**
+**List all samples (enriched)**
+
+Returns `samples` array where `branch` and `order` are objects. `tenant_id` remains an id string.
 
 **Response:**
 ```json
-[
-  {
-    "id": "sample-uuid",
-    "sample_code": "SAMP001",
-    "type": "SANGRE",
-    "state": "RECEIVED",
-    "order_id": "order-uuid-here",
-    "tenant_id": "tenant-uuid-here",
-    "branch_id": "branch-uuid-here"
-  }
-]
+{
+  "samples": [
+    {
+      "id": "sample-uuid",
+      "sample_code": "SAMP001",
+      "type": "SANGRE",
+      "state": "RECEIVED",
+      "tenant_id": "tenant-uuid",
+      "branch": { "id": "branch-uuid", "name": "Main Branch", "code": "MAIN" },
+      "order": { "id": "order-uuid", "order_code": "ORD001", "status": "RECEIVED" }
+    }
+  ]
+}
+```
+
+### GET /api/v1/laboratory/samples/{sample_id}
+**Get sample detail (enriched)**
+
+**Response:**
+```json
+{
+  "id": "sample-uuid",
+  "sample_code": "SAMP001",
+  "type": "SANGRE",
+  "state": "RECEIVED",
+  "collected_at": "2025-08-18T10:00:00Z",
+  "received_at": "2025-08-18T11:00:00Z",
+  "notes": "Blood sample",
+  "tenant_id": "tenant-uuid",
+  "branch": { "id": "branch-uuid", "name": "Main Branch", "code": "MAIN" },
+  "order": { "id": "order-uuid", "order_code": "ORD001", "status": "RECEIVED" },
+  "patient": { "id": "patient-uuid", "full_name": "John Doe", "patient_code": "P001" }
+}
 ```
 
 ### POST /api/v1/laboratory/samples/{sample_id}/images

--- a/API_ENDPOINTS.md
+++ b/API_ENDPOINTS.md
@@ -580,6 +580,12 @@ Response body:
 - Content-Type: `multipart/form-data`
 - Body: field `file` with the image file
 
+**Size Limits:**
+- Regular images (JPG/PNG/WebP, etc.): up to 50MB
+- RAW formats (`.cr2`, `.cr3`, `.nef`, `.nrw`, `.arw`, `.sr2`, `.raf`, `.rw2`, `.orf`, `.pef`, `.dng`): up to 500MB
+
+If the file exceeds the limit, the server returns `413` with a message: `{"detail": "Request body too large...", "type": "request_entity_too_large"}`.
+
 **Behavior:**
 - RAW formats (e.g., CR2/NEF/ARW/DNG): store RAW original + processed JPEG + thumbnail
 - Regular images (e.g., JPG/PNG/WebP): store processed JPEG + thumbnail
@@ -784,6 +790,9 @@ Path param:
 - Uploads the PDF to S3 under a deterministic key
 - Creates a `storage_object` record and assigns `pdf_storage_id` in the target version
 
+**Size Limit:**
+- PDF up to 50MB. Larger uploads will return `413`.
+
 **Response:**
 ```json
 {
@@ -829,6 +838,9 @@ Path param:
 - Selects the newest version by highest `version_no`
 - If no versions exist, returns 404
 - Uploads the PDF to S3 and updates `pdf_storage_id` on that version
+
+**Size Limit:**
+- PDF up to 50MB. Larger uploads will return `413`.
 
 **Response:**
 ```json

--- a/API_ENDPOINTS.md
+++ b/API_ENDPOINTS.md
@@ -785,7 +785,7 @@ Returns `orders` array with enriched `branch` and `patient` objects and summary 
 ### GET /api/v1/laboratory/samples/
 **List all samples (enriched)**
 
-Returns `samples` array where `branch` and `order` are objects. `tenant_id` remains an id string.
+Returns `samples` array where `branch` and `order` are objects. The `order` object now includes `requested_by` and a `patient` object. `tenant_id` remains an id string.
 
 **Response:**
 ```json
@@ -798,7 +798,17 @@ Returns `samples` array where `branch` and `order` are objects. `tenant_id` rema
       "state": "RECEIVED",
       "tenant_id": "tenant-uuid",
       "branch": { "id": "branch-uuid", "name": "Main Branch", "code": "MAIN" },
-      "order": { "id": "order-uuid", "order_code": "ORD001", "status": "RECEIVED" }
+      "order": {
+        "id": "order-uuid",
+        "order_code": "ORD001",
+        "status": "RECEIVED",
+        "requested_by": "Juan Carlos bodoque",
+        "patient": {
+          "id": "d595498b-621d-4edd-9a5d-aacd4e26cf05",
+          "full_name": "Rafael Magaña",
+          "patient_code": "Rima2510"
+        }
+      }
     }
   ]
 }
@@ -820,6 +830,7 @@ Returns `samples` array where `branch` and `order` are objects. `tenant_id` rema
   "tenant_id": "tenant-uuid",
   "branch": { "id": "branch-uuid", "name": "Main Branch", "code": "MAIN" },
   "order": { "id": "order-uuid", "order_code": "ORD001", "status": "RECEIVED" },
+  
   "patient": { "id": "patient-uuid", "full_name": "John Doe", "patient_code": "P001" }
 }
 ```

--- a/API_EXAMPLES.md
+++ b/API_EXAMPLES.md
@@ -638,6 +638,51 @@ PATIENT_ID=patient-uuid-here
 curl "http://localhost:8000/api/v1/laboratory/patients/$PATIENT_ID/orders"
 ```
 
+### List All Orders (enriched)
+```bash
+curl "http://localhost:8000/api/v1/laboratory/orders/"
+```
+
+```python
+import requests
+
+resp = requests.get(f"{BASE_URL}/api/v1/laboratory/orders/")
+resp.raise_for_status()
+data = resp.json()["orders"]
+for o in data:
+    print(o["order_code"], "branch:", o["branch"]["name"], "patient:", o["patient"]["full_name"], "samples:", o["sample_count"]) 
+```
+
+### List All Samples (enriched)
+```bash
+curl "http://localhost:8000/api/v1/laboratory/samples/"
+```
+
+```python
+import requests
+
+resp = requests.get(f"{BASE_URL}/api/v1/laboratory/samples/")
+resp.raise_for_status()
+samples = resp.json()["samples"]
+for s in samples:
+    print(s["sample_code"], "order:", s["order"]["order_code"], "branch:", s["branch"]["name"]) 
+```
+
+### Get Sample Detail (enriched)
+```bash
+SAMPLE_ID=sample-uuid-here
+curl "http://localhost:8000/api/v1/laboratory/samples/$SAMPLE_ID"
+```
+
+```python
+import requests
+
+sample_id = "SAMPLE_UUID"
+resp = requests.get(f"{BASE_URL}/api/v1/laboratory/samples/{sample_id}")
+resp.raise_for_status()
+detail = resp.json()
+print("Sample:", detail["sample_code"], "Order:", detail["order"]["order_code"], "Patient:", detail["patient"]["full_name"]) 
+```
 ```python
 import requests
 

--- a/API_EXAMPLES.md
+++ b/API_EXAMPLES.md
@@ -558,6 +558,11 @@ curl -X POST "http://localhost:8000/api/v1/laboratory/samples/SAMPLE_UUID/images
   -F "file=@/path/to/image.dng"
 ```
 
+Notes:
+- Regular images (JPG/PNG/WebP, etc.) up to 50MB.
+- RAW formats (`.cr2`, `.cr3`, `.nef`, `.nrw`, `.arw`, `.sr2`, `.raf`, `.rw2`, `.orf`, `.pef`, `.dng`) up to 500MB.
+- If the limit is exceeded, the API returns `413`.
+
 **Python Example:**
 ```python
 import requests
@@ -702,6 +707,10 @@ curl -X POST "http://localhost:8000/api/v1/reports/$REPORT_ID/versions/$VERSION_
   -F "file=@${PDF_PATH};type=application/pdf"
 ```
 
+Notes:
+- PDF size up to 50MB.
+- If the limit is exceeded, the API returns `413`.
+
 **Python Example:**
 ```python
 import requests
@@ -728,6 +737,10 @@ curl -X POST "http://localhost:8000/api/v1/reports/$REPORT_ID/pdf" \
   -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
   -F "file=@${PDF_PATH};type=application/pdf"
 ```
+
+Notes:
+- PDF size up to 50MB.
+- If the limit is exceeded, the API returns `413`.
 
 **Python Example:**
 ```python

--- a/API_EXAMPLES.md
+++ b/API_EXAMPLES.md
@@ -552,6 +552,64 @@ if response.status_code == 200:
     print(f"Sample created: {sample['sample_code']}")
 ```
 
+### Create Order with Samples (Unified)
+```bash
+curl -X POST "http://localhost:8000/api/v1/laboratory/orders/unified" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tenant_id": "TENANT_UUID",
+    "branch_id": "BRANCH_UUID",
+    "patient_id": "PATIENT_UUID",
+    "order_code": "ORD001",
+    "requested_by": "Dr. Smith",
+    "samples": [
+      { "sample_code": "SAMP001", "type": "SANGRE" },
+      { "sample_code": "SAMP002", "type": "TEJIDO", "notes": "Fragment" }
+    ]
+  }'
+```
+
+```python
+import requests
+
+payload = {
+    "tenant_id": tenant_id,
+    "branch_id": branch_id,
+    "patient_id": patient_id,
+    "order_code": "ORD001",
+    "requested_by": "Dr. Smith",
+    "samples": [
+        {"sample_code": "SAMP001", "type": "SANGRE"},
+        {"sample_code": "SAMP002", "type": "TEJIDO", "notes": "Fragment"},
+    ],
+}
+
+resp = requests.post(
+    f"{BASE_URL}/api/v1/laboratory/orders/unified",
+    json=payload,
+)
+resp.raise_for_status()
+data = resp.json()
+print("Order:", data["order"]["order_code"], "Samples:", len(data["samples"]))
+```
+
+### Get Full Order Detail (order + patient + samples)
+```bash
+ORDER_ID=order-uuid-here
+curl "http://localhost:8000/api/v1/laboratory/orders/$ORDER_ID/full"
+```
+
+```python
+import requests
+
+order_id = "ORDER_UUID"
+resp = requests.get(f"{BASE_URL}/api/v1/laboratory/orders/{order_id}/full")
+resp.raise_for_status()
+full = resp.json()
+print("Order:", full["order"]["order_code"], "Patient:", full["patient"]["first_name"]) 
+print("Samples:", [s["sample_code"] for s in full["samples"]])
+```
+
 ### Upload Sample Image (multipart/form-data)
 ```bash
 curl -X POST "http://localhost:8000/api/v1/laboratory/samples/SAMPLE_UUID/images" \

--- a/API_EXAMPLES.md
+++ b/API_EXAMPLES.md
@@ -462,7 +462,7 @@ if response.status_code == 200:
     print(f"Patient created: {patient['first_name']} {patient['last_name']}")
 ```
 
-### List All Patients
+### List All Patients (full profile)
 ```bash
 curl http://localhost:8000/api/v1/patients/
 ```
@@ -473,7 +473,9 @@ response = requests.get("http://localhost:8000/api/v1/patients/")
 if response.status_code == 200:
     patients = response.json()
     for patient in patients:
-        print(f"- {patient['first_name']} {patient['last_name']} ({patient['patient_code']})")
+        print(
+            f"- {patient['first_name']} {patient['last_name']} | code={patient['patient_code']} | phone={patient.get('phone')}"
+        )
 ```
 
 ## 🧪 Laboratory Management
@@ -593,7 +595,7 @@ data = resp.json()
 print("Order:", data["order"]["order_code"], "Samples:", len(data["samples"]))
 ```
 
-### Get Full Order Detail (order + patient + samples)
+### Get Full Order Detail (order + patient full + samples)
 ```bash
 ORDER_ID=order-uuid-here
 curl "http://localhost:8000/api/v1/laboratory/orders/$ORDER_ID/full"
@@ -610,7 +612,7 @@ print("Order:", full["order"]["order_code"], "Patient:", full["patient"]["first_
 print("Samples:", [s["sample_code"] for s in full["samples"]])
 ```
 
-### List Cases for a Patient
+### List Cases for a Patient (includes patient full profile)
 ```bash
 PATIENT_ID=patient-uuid-here
 curl "http://localhost:8000/api/v1/laboratory/patients/$PATIENT_ID/cases"
@@ -622,13 +624,15 @@ import requests
 patient_id = "PATIENT_UUID"
 resp = requests.get(f"{BASE_URL}/api/v1/laboratory/patients/{patient_id}/cases")
 resp.raise_for_status()
-cases = resp.json()["cases"]
+data = resp.json()
+print("Patient:", data["patient"]["first_name"], data["patient"]["last_name"], "code:", data["patient"]["patient_code"]) 
+cases = data["cases"]
 for case in cases:
     order = case["order"]
     report = case.get("report")
     print("Order:", order["order_code"], "samples:", len(case["samples"]), "has_report:", bool(report))
 
-### List Orders for a Patient (summary)
+### List Orders for a Patient (summary + patient full)
 ```bash
 PATIENT_ID=patient-uuid-here
 curl "http://localhost:8000/api/v1/laboratory/patients/$PATIENT_ID/orders"
@@ -640,7 +644,9 @@ import requests
 patient_id = "PATIENT_UUID"
 resp = requests.get(f"{BASE_URL}/api/v1/laboratory/patients/{patient_id}/orders")
 resp.raise_for_status()
-orders = resp.json()["orders"]
+data = resp.json()
+print("Patient:", data["patient"]["first_name"], data["patient"]["last_name"], data["patient"]["patient_code"]) 
+orders = data["orders"]
 for o in orders:
     print(o["order_code"], "samples:", o["sample_count"], "has_report:", o["has_report"]) 
 ```

--- a/API_EXAMPLES.md
+++ b/API_EXAMPLES.md
@@ -665,7 +665,13 @@ resp = requests.get(f"{BASE_URL}/api/v1/laboratory/samples/")
 resp.raise_for_status()
 samples = resp.json()["samples"]
 for s in samples:
-    print(s["sample_code"], "order:", s["order"]["order_code"], "branch:", s["branch"]["name"]) 
+    print(
+        s["sample_code"],
+        "order:", s["order"]["order_code"],
+        "branch:", s["branch"]["name"],
+        "patient:", s["order"]["patient"]["full_name"] if s["order"].get("patient") else None,
+        "requested_by:", s["order"].get("requested_by"),
+    ) 
 ```
 
 ### Get Sample Detail (enriched)

--- a/API_EXAMPLES.md
+++ b/API_EXAMPLES.md
@@ -610,6 +610,42 @@ print("Order:", full["order"]["order_code"], "Patient:", full["patient"]["first_
 print("Samples:", [s["sample_code"] for s in full["samples"]])
 ```
 
+### List Cases for a Patient
+```bash
+PATIENT_ID=patient-uuid-here
+curl "http://localhost:8000/api/v1/laboratory/patients/$PATIENT_ID/cases"
+```
+
+```python
+import requests
+
+patient_id = "PATIENT_UUID"
+resp = requests.get(f"{BASE_URL}/api/v1/laboratory/patients/{patient_id}/cases")
+resp.raise_for_status()
+cases = resp.json()["cases"]
+for case in cases:
+    order = case["order"]
+    report = case.get("report")
+    print("Order:", order["order_code"], "samples:", len(case["samples"]), "has_report:", bool(report))
+
+### List Orders for a Patient (summary)
+```bash
+PATIENT_ID=patient-uuid-here
+curl "http://localhost:8000/api/v1/laboratory/patients/$PATIENT_ID/orders"
+```
+
+```python
+import requests
+
+patient_id = "PATIENT_UUID"
+resp = requests.get(f"{BASE_URL}/api/v1/laboratory/patients/{patient_id}/orders")
+resp.raise_for_status()
+orders = resp.json()["orders"]
+for o in orders:
+    print(o["order_code"], "samples:", o["sample_count"], "has_report:", o["has_report"]) 
+```
+```
+
 ### Upload Sample Image (multipart/form-data)
 ```bash
 curl -X POST "http://localhost:8000/api/v1/laboratory/samples/SAMPLE_UUID/images" \

--- a/LOGGING.md
+++ b/LOGGING.md
@@ -76,7 +76,10 @@ logger.info(
 - Injects `X-Request-ID` and adds headers: `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Referrer-Policy`, `Permissions-Policy`.
 
 2) Request Size Limiting
-- Rejects bodies >10MB with `413`.
+- Per-route limits with `413` on exceed:
+  - `/api/v1/laboratory/samples/{sample_id}/images`: handled in endpoint; reads in chunks and enforces 50MB (standard images) or 500MB (RAW formats) based on filename extension.
+  - `/api/v1/reports/.../pdf` and `/api/v1/reports/{report_id}/pdf`: up to 50MB.
+  - Other routes: default 50MB unless explicitly documented.
 
 3) Basic Rate Limiting (in-memory)
 - 100 req/min per IP, returns `429` when exceeded.

--- a/app/api/v1/laboratory.py
+++ b/app/api/v1/laboratory.py
@@ -154,6 +154,7 @@ def list_samples(session: Session = Depends(get_session)):
     for s in samples:
         branch = session.get(Branch, s.branch_id)
         order = session.get(LabOrder, s.order_id)
+        patient = session.get(Patient, order.patient_id) if order else None
         items.append(
             SampleListItem(
                 id=str(s.id),
@@ -162,7 +163,17 @@ def list_samples(session: Session = Depends(get_session)):
                 state=s.state,
                 tenant_id=str(s.tenant_id),
                 branch=BranchRef(id=str(s.branch_id), name=branch.name if branch else "", code=branch.code if branch else None),
-                order=OrderSlim(id=str(s.order_id), order_code=order.order_code if order else "", status=order.status if order else ""),
+                order=OrderSlim(
+                    id=str(s.order_id),
+                    order_code=order.order_code if order else "",
+                    status=order.status if order else "",
+                    requested_by=order.requested_by if order else None,
+                    patient=PatientRef(
+                        id=str(patient.id) if patient else "",
+                        full_name=f"{patient.first_name} {patient.last_name}" if patient else "",
+                        patient_code=patient.patient_code if patient else "",
+                    ) if patient else None,
+                ),
             )
         )
     return SamplesListResponse(samples=items)
@@ -188,7 +199,17 @@ def get_sample_detail(sample_id: str, session: Session = Depends(get_session)):
         notes=s.notes,
         tenant_id=str(s.tenant_id),
         branch=BranchRef(id=str(s.branch_id), name=branch.name if branch else "", code=branch.code if branch else None),
-        order=OrderSlim(id=str(s.order_id), order_code=order.order_code if order else "", status=order.status if order else ""),
+        order=OrderSlim(
+            id=str(s.order_id),
+            order_code=order.order_code if order else "",
+            status=order.status if order else "",
+            requested_by=order.requested_by if order else None,
+            patient=PatientRef(
+                id=str(patient.id) if patient else "",
+                full_name=f"{patient.first_name} {patient.last_name}" if patient else "",
+                patient_code=patient.patient_code if patient else "",
+            ) if patient else None,
+        ),
         patient=PatientRef(
             id=str(patient.id) if patient else "",
             full_name=f"{patient.first_name} {patient.last_name}" if patient else "",

--- a/app/api/v1/laboratory.py
+++ b/app/api/v1/laboratory.py
@@ -25,6 +25,7 @@ from app.schemas.laboratory import (
     PatientOrdersListResponse,
     PatientOrderSummary,
 )
+from app.schemas.report import ReportMetaResponse
 from app.services.s3 import S3Service
 from app.services.image_processing import process_image_bytes
 from uuid import uuid4
@@ -619,7 +620,6 @@ def list_patient_cases(patient_id: str, session: Session = Depends(get_session))
                 .order_by(ReportVersion.version_no.desc())
             ).first()
             has_pdf = bool(current_version and current_version.pdf_storage_id)
-            from app.schemas.report import ReportMetaResponse  # local import to avoid cycles
             report_meta = ReportMetaResponse(
                 id=str(report.id),
                 status=report.status,

--- a/app/schemas/laboratory.py
+++ b/app/schemas/laboratory.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel
 from typing import Optional, List, Dict
 from datetime import datetime
 from app.schemas.report import ReportMetaResponse
+from app.schemas.patient import PatientFullResponse
 
 class LabOrderCreate(BaseModel):
     """Schema for creating a laboratory order"""
@@ -111,7 +112,7 @@ class LabOrderUnifiedResponse(BaseModel):
 class LabOrderFullDetailResponse(BaseModel):
     """Complete detail for a lab order: order, patient, and samples."""
     order: LabOrderDetailResponse
-    patient: Dict[str, Optional[str]]
+    patient: PatientFullResponse
     samples: List[SampleResponse]
     report: Optional[ReportMetaResponse] = None
 
@@ -134,7 +135,8 @@ class PatientCaseDetail(BaseModel):
 
 
 class PatientCasesListResponse(BaseModel):
-    """List of cases (orders) for a patient."""
+    """List of cases (orders) for a patient, including full patient profile."""
+    patient: PatientFullResponse
     patient_id: str
     cases: List[PatientCaseDetail]
 
@@ -155,6 +157,6 @@ class PatientOrderSummary(BaseModel):
 
 
 class PatientOrdersListResponse(BaseModel):
-    """List of orders for a patient (summary)."""
-    patient_id: str
+    """List of orders for a patient (summary) with full patient profile."""
+    patient: PatientFullResponse
     orders: List[PatientOrderSummary]

--- a/app/schemas/laboratory.py
+++ b/app/schemas/laboratory.py
@@ -183,6 +183,8 @@ class OrderSlim(BaseModel):
     id: str
     order_code: str
     status: str
+    requested_by: Optional[str] = None
+    patient: Optional[PatientRef] = None
 
 
 class OrderListItem(BaseModel):

--- a/app/schemas/laboratory.py
+++ b/app/schemas/laboratory.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel
 from typing import Optional, List, Dict
 from datetime import datetime
+from app.schemas.report import ReportMetaResponse
 
 class LabOrderCreate(BaseModel):
     """Schema for creating a laboratory order"""
@@ -112,3 +113,48 @@ class LabOrderFullDetailResponse(BaseModel):
     order: LabOrderDetailResponse
     patient: Dict[str, Optional[str]]
     samples: List[SampleResponse]
+    report: Optional[ReportMetaResponse] = None
+
+
+class PatientCaseSummary(BaseModel):
+    """Summary of a case (order) for a given patient."""
+    id: str
+    order_code: str
+    status: str
+    tenant_id: str
+    branch_id: str
+    created_at: Optional[str] = None
+
+
+class PatientCaseDetail(BaseModel):
+    """Detailed case info: order + samples + report meta (if any)."""
+    order: LabOrderDetailResponse
+    samples: List[SampleResponse]
+    report: Optional[ReportMetaResponse] = None
+
+
+class PatientCasesListResponse(BaseModel):
+    """List of cases (orders) for a patient."""
+    patient_id: str
+    cases: List[PatientCaseDetail]
+
+
+class PatientOrderSummary(BaseModel):
+    """Enriched summary of an order for list endpoint."""
+    id: str
+    order_code: str
+    status: str
+    tenant_id: str
+    branch_id: str
+    patient_id: str
+    requested_by: Optional[str] = None
+    notes: Optional[str] = None
+    created_at: Optional[str] = None
+    sample_count: int
+    has_report: bool
+
+
+class PatientOrdersListResponse(BaseModel):
+    """List of orders for a patient (summary)."""
+    patient_id: str
+    orders: List[PatientOrderSummary]

--- a/app/schemas/laboratory.py
+++ b/app/schemas/laboratory.py
@@ -160,3 +160,77 @@ class PatientOrdersListResponse(BaseModel):
     """List of orders for a patient (summary) with full patient profile."""
     patient: PatientFullResponse
     orders: List[PatientOrderSummary]
+
+
+# --- Shared small refs for enriched list endpoints ---
+
+class BranchRef(BaseModel):
+    """Minimal branch reference with id and human-readable name (and optional code)."""
+    id: str
+    name: str
+    code: Optional[str] = None
+
+
+class PatientRef(BaseModel):
+    """Minimal patient reference for lists with full name and code."""
+    id: str
+    full_name: str
+    patient_code: str
+
+
+class OrderSlim(BaseModel):
+    """Small order reference for sample lists/details."""
+    id: str
+    order_code: str
+    status: str
+
+
+class OrderListItem(BaseModel):
+    """Order item for GET /laboratory/orders/ with enriched references."""
+    id: str
+    order_code: str
+    status: str
+    tenant_id: str
+    branch: BranchRef
+    patient: PatientRef
+    requested_by: Optional[str] = None
+    notes: Optional[str] = None
+    created_at: Optional[str] = None
+    sample_count: int
+    has_report: bool
+
+
+class OrdersListResponse(BaseModel):
+    """Response for GET /laboratory/orders/ with enriched items."""
+    orders: List[OrderListItem]
+
+
+class SampleListItem(BaseModel):
+    """Sample item with enriched branch and order objects (tenant_id kept as id)."""
+    id: str
+    sample_code: str
+    type: str
+    state: str
+    tenant_id: str
+    branch: BranchRef
+    order: OrderSlim
+
+
+class SamplesListResponse(BaseModel):
+    """Response for GET /laboratory/samples/ with enriched items."""
+    samples: List[SampleListItem]
+
+
+class SampleDetailResponse(BaseModel):
+    """Complete detail for a sample including branch, order, and patient references."""
+    id: str
+    sample_code: str
+    type: str
+    state: str
+    collected_at: Optional[str] = None
+    received_at: Optional[str] = None
+    notes: Optional[str] = None
+    tenant_id: str
+    branch: BranchRef
+    order: OrderSlim
+    patient: PatientRef

--- a/app/schemas/laboratory.py
+++ b/app/schemas/laboratory.py
@@ -78,3 +78,37 @@ class SampleImageUploadResponse(BaseModel):
     is_raw: bool
     file_size: int
     urls: Dict[str, str]
+
+
+class UnifiedSampleCreate(BaseModel):
+    """Input schema for creating a sample as part of unified order creation."""
+    sample_code: str
+    type: str
+    notes: Optional[str] = None
+    collected_at: Optional[datetime] = None
+    received_at: Optional[datetime] = None
+
+
+class LabOrderUnifiedCreate(BaseModel):
+    """Unified create: create lab order and one or more samples in one operation."""
+    tenant_id: str
+    branch_id: str
+    patient_id: str
+    order_code: str
+    requested_by: Optional[str] = None
+    notes: Optional[str] = None
+    created_by: Optional[str] = None
+    samples: List[UnifiedSampleCreate]
+
+
+class LabOrderUnifiedResponse(BaseModel):
+    """Response for unified create, returning order and samples created."""
+    order: LabOrderResponse
+    samples: List[SampleResponse]
+
+
+class LabOrderFullDetailResponse(BaseModel):
+    """Complete detail for a lab order: order, patient, and samples."""
+    order: LabOrderDetailResponse
+    patient: Dict[str, Optional[str]]
+    samples: List[SampleResponse]

--- a/app/schemas/patient.py
+++ b/app/schemas/patient.py
@@ -35,3 +35,17 @@ class PatientDetailResponse(BaseModel):
     email: Optional[str] = None
     tenant_id: str
     branch_id: str
+
+
+class PatientFullResponse(BaseModel):
+    """Schema for full patient profile used across endpoints."""
+    id: str
+    tenant_id: str
+    branch_id: str
+    patient_code: str
+    first_name: str
+    last_name: str
+    dob: Optional[date] = None
+    sex: Optional[str] = None
+    phone: Optional[str] = None
+    email: Optional[str] = None

--- a/app/schemas/report.py
+++ b/app/schemas/report.py
@@ -51,3 +51,13 @@ class ReportVersionResponse(BaseModel):
     version_no: int
     report_id: str
     is_current: bool
+
+
+class ReportMetaResponse(BaseModel):
+    """Lightweight report metadata for case listings."""
+    id: str
+    status: str
+    title: Optional[str] = None
+    published_at: Optional[datetime] = None
+    version_no: Optional[int] = None
+    has_pdf: bool = False


### PR DESCRIPTION
This pull request introduces significant enhancements and clarifications to the laboratory and patient API endpoints, focusing on enriched data responses, unified operations, and improved documentation of request size limits. The changes affect both the API documentation and the implementation, especially around patient profiles, laboratory order/sample enrichment, and file upload constraints.

Key changes include:

**API Response Enrichment and Unification:**

- The `/api/v1/patients/` endpoint now returns full patient profiles (`PatientFullResponse`) with additional fields such as `dob`, `sex`, `phone`, and `email`, both in the API and example scripts. [[1]](diffhunk://#diff-2228edde3c2c869a4d2d631a9be8384086ef89e3c6634506331c78bac8451bf9L425-R442) [[2]](diffhunk://#diff-1a3a0bb0c236c16463e75965c4b2a48456d41bb9de07910576d87e2d30f7357cL6-R28) [[3]](diffhunk://#diff-5b9a40ed86152c57c7909b5feaf67a4bd16e35ed420730e1ce8455cbb050b8b7L465-R465) [[4]](diffhunk://#diff-5b9a40ed86152c57c7909b5feaf67a4bd16e35ed420730e1ce8455cbb050b8b7L476-R478)
- Laboratory order and sample listing endpoints (`/api/v1/laboratory/orders/`, `/api/v1/laboratory/samples/`) now return enriched objects, including nested `branch`, `patient`, and `order` details, as well as summary fields like `sample_count` and `has_report`. [[1]](diffhunk://#diff-2228edde3c2c869a4d2d631a9be8384086ef89e3c6634506331c78bac8451bf9L494-R522) [[2]](diffhunk://#diff-2228edde3c2c869a4d2d631a9be8384086ef89e3c6634506331c78bac8451bf9L559-R835) [[3]](diffhunk://#diff-5b9a40ed86152c57c7909b5feaf67a4bd16e35ed420730e1ce8455cbb050b8b7R557-R716)
- New unified endpoint `/api/v1/laboratory/orders/unified` allows creating a laboratory order and multiple samples in a single operation, with comprehensive request/response examples and error handling. [[1]](diffhunk://#diff-2228edde3c2c869a4d2d631a9be8384086ef89e3c6634506331c78bac8451bf9R545-R756) [[2]](diffhunk://#diff-5b9a40ed86152c57c7909b5feaf67a4bd16e35ed420730e1ce8455cbb050b8b7R557-R716)

**Detailed Case and Order Retrieval:**

- Added endpoints for retrieving complete order details (`/api/v1/laboratory/orders/{order_id}/full`), all orders for a patient with full patient info, and complete cases for a patient (including order, samples, and report metadata). These endpoints are documented with sample responses and error cases. [[1]](diffhunk://#diff-2228edde3c2c869a4d2d631a9be8384086ef89e3c6634506331c78bac8451bf9R545-R756) [[2]](diffhunk://#diff-5b9a40ed86152c57c7909b5feaf67a4bd16e35ed420730e1ce8455cbb050b8b7R557-R716)

**File Upload and Request Size Limiting:**

- File upload endpoints now have clearly documented and enforced size limits: standard images and PDFs up to 50MB, RAW image formats up to 500MB. Exceeding these limits returns a `413` error. This is reflected in both the documentation and the request size limiting middleware. [[1]](diffhunk://#diff-2228edde3c2c869a4d2d631a9be8384086ef89e3c6634506331c78bac8451bf9R845-R850) [[2]](diffhunk://#diff-2228edde3c2c869a4d2d631a9be8384086ef89e3c6634506331c78bac8451bf9R1055-R1057) [[3]](diffhunk://#diff-2228edde3c2c869a4d2d631a9be8384086ef89e3c6634506331c78bac8451bf9R1104-R1106) [[4]](diffhunk://#diff-ea3e9ebce11a5deb9d816a3ab0652015228783fe9f408517e876e33ddb4c4223L79-R82) [[5]](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddL94-R126) [[6]](diffhunk://#diff-5b9a40ed86152c57c7909b5feaf67a4bd16e35ed420730e1ce8455cbb050b8b7R861-R864) [[7]](diffhunk://#diff-5b9a40ed86152c57c7909b5feaf67a4bd16e35ed420730e1ce8455cbb050b8b7R892-R895)

**Documentation and Example Updates:**

- The API documentation (`API_ENDPOINTS.md`) and example scripts (`API_EXAMPLES.md`) have been updated to reflect all new fields, enriched responses, new endpoints, and file size limits, providing clear guidance and sample code for users. [[1]](diffhunk://#diff-2228edde3c2c869a4d2d631a9be8384086ef89e3c6634506331c78bac8451bf9L425-R442) [[2]](diffhunk://#diff-2228edde3c2c869a4d2d631a9be8384086ef89e3c6634506331c78bac8451bf9L494-R522) [[3]](diffhunk://#diff-2228edde3c2c869a4d2d631a9be8384086ef89e3c6634506331c78bac8451bf9R545-R756) [[4]](diffhunk://#diff-2228edde3c2c869a4d2d631a9be8384086ef89e3c6634506331c78bac8451bf9L559-R835) [[5]](diffhunk://#diff-2228edde3c2c869a4d2d631a9be8384086ef89e3c6634506331c78bac8451bf9R845-R850) [[6]](diffhunk://#diff-2228edde3c2c869a4d2d631a9be8384086ef89e3c6634506331c78bac8451bf9R1055-R1057) [[7]](diffhunk://#diff-2228edde3c2c869a4d2d631a9be8384086ef89e3c6634506331c78bac8451bf9R1104-R1106) [[8]](diffhunk://#diff-5b9a40ed86152c57c7909b5feaf67a4bd16e35ed420730e1ce8455cbb050b8b7L465-R465) [[9]](diffhunk://#diff-5b9a40ed86152c57c7909b5feaf67a4bd16e35ed420730e1ce8455cbb050b8b7L476-R478) [[10]](diffhunk://#diff-5b9a40ed86152c57c7909b5feaf67a4bd16e35ed420730e1ce8455cbb050b8b7R557-R716) [[11]](diffhunk://#diff-5b9a40ed86152c57c7909b5feaf67a4bd16e35ed420730e1ce8455cbb050b8b7R861-R864) [[12]](diffhunk://#diff-5b9a40ed86152c57c7909b5feaf67a4bd16e35ed420730e1ce8455cbb050b8b7R892-R895)

**Schema and Dependency Updates:**

- The backend now uses the `PatientFullResponse` schema for patient listing and imports it where needed for laboratory case responses. [[1]](diffhunk://#diff-1a3a0bb0c236c16463e75965c4b2a48456d41bb9de07910576d87e2d30f7357cL6-R28) [[2]](diffhunk://#diff-4aa46152ce7b82bea95dd7a2b1abe2883f9d8c9c1122feed7ea9a737296698beR4-R5)

These improvements provide more complete and useful data to API consumers, streamline common operations, and ensure robust handling of large file uploads.