### PR TITLE
chore: add Docker Hub login step to CI and PR workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Set up QEMU (multi-arch emulation)
         uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -88,6 +95,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Set up QEMU (multi-arch emulation)
         uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,6 +52,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Set up QEMU (multi-arch emulation)
         uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to add Docker Hub authentication before running Docker-related steps. This ensures that Docker commands can authenticate and interact with Docker Hub as needed during CI and PR workflows.

Workflow authentication improvements:

* Added a Docker Hub login step using `docker/login-action@v3` with credentials from repository secrets in the `ci.yml` workflow.
* Added the same Docker Hub login step to the `pr.yml` workflow.
* Duplicated the Docker Hub login step for another job within `ci.yml` to ensure all relevant jobs authenticate with Docker Hub.