### PR TITLE
feat: enrich reports list endpoint with branch, order, patient info

### DIFF
--- a/API_ENDPOINTS.md
+++ b/API_ENDPOINTS.md
@@ -956,19 +956,44 @@ Headers: `Authorization: Bearer <token>`
 ```
 
 ### GET /api/v1/reports/
-**List all reports**
+**List all reports (enriched)**
+
+Returns `reports` array with enriched `branch`, `order`, and `patient` objects plus version metadata.
 
 **Response:**
 ```json
-[
-  {
-    "id": "report-uuid",
-    "status": "DRAFT",
-    "order_id": "order-uuid-here",
-    "tenant_id": "tenant-uuid-here",
-    "branch_id": "branch-uuid-here"
-  }
-]
+{
+  "reports": [
+    {
+      "id": "report-uuid",
+      "status": "PUBLISHED",
+      "tenant_id": "tenant-uuid",
+      "branch": {
+        "id": "branch-uuid",
+        "name": "Main Branch",
+        "code": "MAIN"
+      },
+      "order": {
+        "id": "order-uuid",
+        "order_code": "ORD001",
+        "status": "COMPLETED",
+        "requested_by": "Dr. Smith",
+        "patient": {
+          "id": "patient-uuid",
+          "full_name": "John Doe",
+          "patient_code": "P001"
+        }
+      },
+      "title": "Blood Test Report",
+      "diagnosis_text": "Normal blood count results",
+      "published_at": "2025-08-18T12:00:00Z",
+      "created_at": "2025-08-18T10:00:00Z",
+      "created_by": "user-uuid",
+      "version_no": 2,
+      "has_pdf": true
+    }
+  ]
+}
 ```
 
 ### GET /api/v1/reports/{report_id}

--- a/app/schemas/report.py
+++ b/app/schemas/report.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 from datetime import datetime
 
 class ReportCreate(BaseModel):
@@ -61,3 +61,43 @@ class ReportMetaResponse(BaseModel):
     published_at: Optional[datetime] = None
     version_no: Optional[int] = None
     has_pdf: bool = False
+
+# Schemas for enriched list responses
+class BranchRef(BaseModel):
+    """Reference to a branch with basic info"""
+    id: str
+    name: str
+    code: Optional[str] = None
+
+class PatientRef(BaseModel):
+    """Reference to a patient with basic info"""
+    id: str
+    full_name: str
+    patient_code: str
+
+class OrderRef(BaseModel):
+    """Reference to an order with basic info"""
+    id: str
+    order_code: str
+    status: str
+    requested_by: Optional[str] = None
+    patient: Optional[PatientRef] = None
+
+class ReportListItem(BaseModel):
+    """Enriched report item for list view"""
+    id: str
+    status: str
+    tenant_id: str
+    branch: BranchRef
+    order: OrderRef
+    title: Optional[str] = None
+    diagnosis_text: Optional[str] = None
+    published_at: Optional[datetime] = None
+    created_at: Optional[str] = None
+    created_by: Optional[str] = None
+    version_no: Optional[int] = None
+    has_pdf: bool = False
+
+class ReportsListResponse(BaseModel):
+    """Response schema for reports list"""
+    reports: List[ReportListItem]


### PR DESCRIPTION
This pull request enhances the reports API by enriching the data returned for the list reports endpoint, updating the documentation and examples to reflect these changes, and introducing new response schemas for more detailed and structured output. The main focus is to provide clients with more comprehensive information about each report, including related branch, order, and patient details, as well as version metadata.

**API Endpoint Improvements:**
* The `/api/v1/reports/` endpoint now returns a structured response with enriched `branch`, `order`, and `patient` objects, along with version metadata, instead of basic IDs. This makes it easier for clients to display and work with report data.

**Schema and Model Updates:**
* New Pydantic models (`BranchRef`, `OrderRef`, `PatientRef`, `ReportListItem`, `ReportsListResponse`) are introduced in `app/schemas/report.py` to define the enriched response structure for the report list endpoint. [[1]](diffhunk://#diff-5623625e58284cb967d8fb98fd87551dfbe918e953380f2a19644cb53644c409R64-R103) [[2]](diffhunk://#diff-5623625e58284cb967d8fb98fd87551dfbe918e953380f2a19644cb53644c409L2-R2)

**Documentation Updates:**
* The API documentation in `API_ENDPOINTS.md` is updated to describe the new enriched response format for the list reports endpoint, including example responses.

**Example and Usage Updates:**
* The API usage examples in `API_EXAMPLES.md` are updated to show how to consume the enriched report list response, both in curl and Python, including how to access nested branch, order, and patient info. [[1]](diffhunk://#diff-5b9a40ed86152c57c7909b5feaf67a4bd16e35ed420730e1ce8455cbb050b8b7L836-R898) [[2]](diffhunk://#diff-5b9a40ed86152c57c7909b5feaf67a4bd16e35ed420730e1ce8455cbb050b8b7L957-R1029)- Add new schemas: BranchRef, PatientRef, OrderRef, ReportListItem, 