### PR TITLE
Fix migration: use order_id instead of report_id in index

### DIFF
--- a/alembic/versions/270866acafe7_normalize_assignments_and_reviews.py
+++ b/alembic/versions/270866acafe7_normalize_assignments_and_reviews.py
@@ -159,7 +159,7 @@ def upgrade() -> None:
     # Create partial unique index for pending reviews
     op.execute("""
         CREATE UNIQUE INDEX ix_report_review_unique_pending 
-        ON report_review (tenant_id, report_id, reviewer_user_id) 
+        ON report_review (tenant_id, order_id, reviewer_user_id) 
         WHERE status = 'PENDING'
     """)
     


### PR DESCRIPTION
This pull request updates the database migration script to fix a unique index definition related to pending reviews. The change ensures that the unique constraint is applied to the correct set of columns, which likely resolves an issue with review assignment uniqueness.

Database schema correction:

* Updated the unique index `ix_report_review_unique_pending` in `alembic/versions/270866acafe7_normalize_assignments_and_reviews.py` to use `order_id` instead of `report_id` as part of the unique constraint on the `report_review` table for pending reviews.