### PR TITLE
fix: allow all hosts in TrustedHostMiddleware behind nginx proxy

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -44,9 +44,11 @@ app = FastAPI(
 )
 
 # Add security middlewares
+# Allow all hosts since the backend sits behind the nginx reverse proxy;
+# host validation is the proxy's responsibility.
 app.add_middleware(
-    TrustedHostMiddleware, 
-    allowed_hosts=["localhost", "127.0.0.1", "*.localhost", "backend", "frontend"]
+    TrustedHostMiddleware,
+    allowed_hosts=["*"],
 )
 
 # Add CORS middleware (more secure in production)


### PR DESCRIPTION
This pull request makes a small but important change to the FastAPI application's security configuration. The change updates the `TrustedHostMiddleware` to allow requests from all hosts, with the explanation that host validation is handled by the nginx reverse proxy in front of the backend.

* Security middleware update:
  * In `app/main.py`, changed `TrustedHostMiddleware` to accept all hosts by setting `allowed_hosts=["*"]`, since host validation is delegated to the nginx proxy.