### PR TITLE
Enhance invoice creation with order status updates and error handling

### DIFF
--- a/app/api/v1/billing.py
+++ b/app/api/v1/billing.py
@@ -142,7 +142,12 @@ def create_invoice_for_order(session: Session, order: Order) -> Invoice:
             "total": unit_price,
         },
     )
-    
+
+    # Set billed_lock so the order cannot be released before payment
+    update_order_payment_lock(session, str(order.id))
+    from app.api.v1.laboratory import update_order_status
+    update_order_status(str(order.id), session)
+
     return invoice
 
 
@@ -300,6 +305,20 @@ def create_invoice(
     )
     
     session.add(invoice)
+    session.flush()  # Get invoice.id before updating locks
+
+    # Recalculate payment lock and order status so a manually created invoice
+    # also blocks the order from being released before payment.
+    update_order_payment_lock(session, str(invoice_data.order_id))
+    try:
+        from app.api.v1.laboratory import update_order_status
+        update_order_status(str(invoice_data.order_id), session)
+    except Exception as e:
+        logger.warning(
+            f"Could not update order status after manual invoice creation: {e}",
+            extra={"event": "order.status_update_skipped", "order_id": str(invoice_data.order_id)},
+        )
+
     session.commit()
     session.refresh(invoice)
     

--- a/app/api/v1/reports.py
+++ b/app/api/v1/reports.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
 from sqlmodel import select, Session, and_
 from sqlalchemy import cast, String
+from sqlalchemy.orm.attributes import flag_modified
 from app.core.db import get_session
 from app.api.v1.auth import get_auth_ctx, AuthContext, current_user
 from app.models.report import Report, ReportVersion, ReportTemplate
@@ -613,6 +614,7 @@ def update_template(
         template.description = template_data.description
     if template_data.template_json is not None:
         template.template_json = template_data.template_json
+        flag_modified(template, "template_json")
     if template_data.is_active is not None:
         template.is_active = template_data.is_active
     


### PR DESCRIPTION
This pull request introduces improvements to the billing and reporting modules, primarily to ensure that orders are properly locked and their statuses updated when invoices are created, and to guarantee that changes to report templates are correctly persisted in the database.

**Billing and Order Locking Enhancements:**

- Ensures that when an invoice is created for an order (both automatically and manually), the order is payment-locked and its status is updated to prevent premature release before payment. This includes error handling and logging for manual invoice creation. [[1]](diffhunk://#diff-f73f30a384deb9c551f7ff164250f913e70dddec1907fcf4be8083881a1cb6a8R146-R150) [[2]](diffhunk://#diff-f73f30a384deb9c551f7ff164250f913e70dddec1907fcf4be8083881a1cb6a8R308-R321)

**Reporting Module Fixes:**

- Adds the use of `flag_modified` from SQLAlchemy to explicitly mark the `template_json` field as changed when updating a report template, ensuring that modifications are saved to the database. [[1]](diffhunk://#diff-21455e62eb86d583ad639b4e7522e40ca499c50d5098e4e2784e2dc434ef9452R4) [[2]](diffhunk://#diff-21455e62eb86d583ad639b4e7522e40ca499c50d5098e4e2784e2dc434ef9452R617)