### PR TITLE
Enhance deployment process with ECS integration and DB_URL logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,38 @@ jobs:
           echo "- ${{ steps.login-ecr.outputs.registry }}/celuma-stg/celuma-backend:stg-${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
           echo "- ${{ steps.login-ecr.outputs.registry }}/celuma-stg/celuma-backend:stg-latest" >> $GITHUB_STEP_SUMMARY
 
+  deploy-stg:
+    needs: docker-build-main
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    permissions:
+      id-token: write   # OIDC for AWS
+      contents: read
+
+    steps:
+      - name: Configure AWS (OIDC, deploy role)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::385511156241:role/GitHubActionsECSDeployRole
+          aws-region: mx-central-1
+
+      - name: Force new ECS deployment (stg)
+        run: |
+          aws ecs update-service \
+            --cluster celuma-stg \
+            --service celuma-stg-backend \
+            --force-new-deployment \
+            --no-cli-pager > /dev/null
+          echo "Triggered rolling deploy for celuma-stg-backend"
+
+      - name: Wait for service stability
+        run: |
+          aws ecs wait services-stable \
+            --cluster celuma-stg \
+            --services celuma-stg-backend
+          echo "### ✅ Backend deployed to stg (${{ github.sha }})" >> $GITHUB_STEP_SUMMARY
+
   docker-release:
     runs-on: ubuntu-latest
     if: >
@@ -172,3 +204,37 @@ jobs:
           echo "- ${{ steps.login-ecr.outputs.registry }}/celuma/celuma-backend:${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
           echo "- ${{ steps.login-ecr.outputs.registry }}/celuma/celuma-backend:${{ steps.release_version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "- ${{ steps.login-ecr.outputs.registry }}/celuma/celuma-backend:latest" >> $GITHUB_STEP_SUMMARY
+
+  deploy-prod:
+    needs: docker-release
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags/v')
+
+    permissions:
+      id-token: write   # OIDC for AWS
+      contents: read
+
+    steps:
+      - name: Configure AWS (OIDC, deploy role)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::385511156241:role/GitHubActionsECSDeployRole
+          aws-region: mx-central-1
+
+      - name: Force new ECS deployment (prod)
+        run: |
+          aws ecs update-service \
+            --cluster celuma-prod \
+            --service celuma-prod-backend \
+            --force-new-deployment \
+            --no-cli-pager > /dev/null
+          echo "Triggered rolling deploy for celuma-prod-backend"
+
+      - name: Wait for service stability
+        run: |
+          aws ecs wait services-stable \
+            --cluster celuma-prod \
+            --services celuma-prod-backend
+          echo "### ✅ Backend deployed to prod (${{ github.ref_name }})" >> $GITHUB_STEP_SUMMARY

--- a/start.sh
+++ b/start.sh
@@ -4,6 +4,22 @@ set -e  # Exit on any error
 
 echo "Starting Celuma Backend..."
 
+# If DATABASE_URL is not provided (e.g. on ECS, where the cluster credentials
+# arrive split across DB_HOST/DB_PORT/DB_USER/DB_PASSWORD/DB_NAME), build it
+# from those parts. Local docker-compose still works because it sets
+# DATABASE_URL directly.
+if [ -z "${DATABASE_URL}" ]; then
+    if [ -n "${DB_HOST}" ] && [ -n "${DB_USER}" ] && [ -n "${DB_PASSWORD}" ]; then
+        DB_PORT="${DB_PORT:-5432}"
+        DB_NAME="${DB_NAME:-celumadb}"
+        export DATABASE_URL="postgresql+psycopg2://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}"
+        echo "DATABASE_URL composed from DB_* environment variables"
+    else
+        echo "ERROR: DATABASE_URL is not set and DB_* variables are incomplete"
+        exit 1
+    fi
+fi
+
 # Function to check database connection
 check_db() {
     echo "Checking database connection..."


### PR DESCRIPTION
This pull request introduces automated deployment steps to both staging and production environments via GitHub Actions, and improves the startup script to better handle database connection configuration. The main changes are the addition of new deployment jobs in the CI workflow and enhanced flexibility in how the backend service determines its database connection string.

**CI/CD workflow enhancements:**

* Added a `deploy-stg` job to `.github/workflows/ci.yml` that automatically deploys the backend to the staging ECS cluster after a successful build on the `main` branch. This job uses OIDC for AWS authentication and waits for the service to stabilize before reporting success.
* Added a `deploy-prod` job to `.github/workflows/ci.yml` that deploys the backend to the production ECS cluster when a new version tag is pushed. Like the staging job, it uses OIDC for AWS authentication and waits for service stability.

**Startup script improvements:**

* Updated `start.sh` to automatically compose the `DATABASE_URL` environment variable from individual `DB_*` variables if `DATABASE_URL` is not set, improving compatibility with ECS and other environments where credentials are provided separately. The script now exits with an error if neither a complete `DATABASE_URL` nor the necessary `DB_*` variables are present.