### PR TITLE
Implement digital signature functionality and improve migration handling

### DIFF
--- a/alembic/versions/v1_1_0_digital_signature.py
+++ b/alembic/versions/v1_1_0_digital_signature.py
@@ -1,0 +1,156 @@
+"""v1.1.0 - Digital signature: app_user.signature_storage_id + reviewer role
+
+Revision ID: v1_1_0
+Revises: v1_0_0
+Create Date: 2026-05-13
+
+Changes:
+  - DDL: add app_user.signature_storage_id (FK to storage_object.id, nullable)
+  - DML: insert new system role 'reviewer' with permissions
+         reports:read, reports:approve, reports:sign, lab:read, lab:manage_reviewers
+  - DML: remove permission 'reports:sign' from system role 'pathologist'
+
+Downgrade restores the previous state (re-grants reports:sign to pathologist,
+deletes the reviewer role and its permissions, and drops the new column).
+"""
+from typing import Sequence, Union
+import uuid as _uuid
+from datetime import datetime
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "v1_1_0"
+down_revision: Union[str, Sequence[str], None] = "v1_0_0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+REVIEWER_PERMISSIONS = (
+    "reports:read",
+    "reports:approve",
+    "reports:sign",
+    "lab:read",
+    "lab:manage_reviewers",
+)
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # 1. DDL: app_user.signature_storage_id
+    # ------------------------------------------------------------------
+    op.add_column(
+        "app_user",
+        sa.Column(
+            "signature_storage_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+    )
+    op.create_foreign_key(
+        "app_user_signature_storage_id_fkey",
+        source_table="app_user",
+        referent_table="storage_object",
+        local_cols=["signature_storage_id"],
+        remote_cols=["id"],
+    )
+
+    # ------------------------------------------------------------------
+    # 2. DML: seed 'reviewer' role
+    # ------------------------------------------------------------------
+    role_table = sa.table(
+        "role",
+        sa.column("id", postgresql.UUID(as_uuid=True)),
+        sa.column("created_at", sa.DateTime),
+        sa.column("code", sa.String),
+        sa.column("name", sa.String),
+        sa.column("description", sa.String),
+        sa.column("is_system", sa.Boolean),
+        sa.column("is_protected", sa.Boolean),
+        sa.column("tenant_id", postgresql.UUID(as_uuid=True)),
+    )
+
+    reviewer_role_id = _uuid.uuid4()
+    op.bulk_insert(role_table, [{
+        "id": reviewer_role_id,
+        "created_at": datetime.utcnow(),
+        "code": "reviewer",
+        "name": "Revisor",
+        "description": "Revisión y firma digital de informes patológicos.",
+        "is_system": True,
+        "is_protected": False,
+        "tenant_id": None,
+    }])
+
+    # ------------------------------------------------------------------
+    # 3. DML: seed reviewer's permissions
+    # ------------------------------------------------------------------
+    op.execute(
+        f"""
+        INSERT INTO public.role_permission (role_id, permission_id)
+        SELECT r.id, p.id
+        FROM public.role r
+        CROSS JOIN public.permission p
+        WHERE r.code = 'reviewer'
+          AND p.code IN ({", ".join(f"'{c}'" for c in REVIEWER_PERMISSIONS)})
+        """
+    )
+
+    # ------------------------------------------------------------------
+    # 4. DML: revoke 'reports:sign' from 'pathologist'
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        DELETE FROM public.role_permission rp
+        USING public.role r, public.permission p
+        WHERE rp.role_id = r.id
+          AND rp.permission_id = p.id
+          AND r.code = 'pathologist'
+          AND p.code = 'reports:sign'
+        """
+    )
+
+
+def downgrade() -> None:
+    # ------------------------------------------------------------------
+    # 1. DML: restore 'reports:sign' on 'pathologist'
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        INSERT INTO public.role_permission (role_id, permission_id)
+        SELECT r.id, p.id
+        FROM public.role r
+        CROSS JOIN public.permission p
+        WHERE r.code = 'pathologist'
+          AND p.code = 'reports:sign'
+          AND NOT EXISTS (
+              SELECT 1
+              FROM public.role_permission existing
+              WHERE existing.role_id = r.id
+                AND existing.permission_id = p.id
+          )
+        """
+    )
+
+    # ------------------------------------------------------------------
+    # 2. DML: drop reviewer role-permission rows + role
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        DELETE FROM public.role_permission
+        WHERE role_id IN (SELECT id FROM public.role WHERE code = 'reviewer')
+        """
+    )
+    op.execute("DELETE FROM public.role WHERE code = 'reviewer'")
+
+    # ------------------------------------------------------------------
+    # 3. DDL: drop app_user.signature_storage_id
+    # ------------------------------------------------------------------
+    op.drop_constraint(
+        "app_user_signature_storage_id_fkey",
+        "app_user",
+        type_="foreignkey",
+    )
+    op.drop_column("app_user", "signature_storage_id")

--- a/app/api/v1/laboratory.py
+++ b/app/api/v1/laboratory.py
@@ -5,7 +5,7 @@ from sqlmodel import select, Session, and_, func
 from sqlalchemy import cast, String
 from app.core.db import get_session
 from app.api.v1.auth import get_auth_ctx, AuthContext, current_user
-from app.core.rbac import has_permission
+from app.core.rbac import has_permission, get_user_roles, ROLE_REVIEWER
 from app.models.laboratory import Order, Sample, SampleImage, Label, OrderLabel, SampleLabel
 from app.models.storage import StorageObject, SampleImageRendition
 from app.models.tenant import Tenant, Branch
@@ -2546,14 +2546,19 @@ def update_order_reviewers(
     if str(order.tenant_id) != ctx.tenant_id:
         raise HTTPException(403, "Order does not belong to your tenant")
     
-    # Validate all reviewer IDs belong to tenant
+    # Validate all reviewer IDs belong to tenant and have the 'reviewer' role
     new_reviewers = set()
     for rid in data.reviewer_ids:
         reviewer_user = session.get(AppUser, UUID(rid))
         if not reviewer_user or str(reviewer_user.tenant_id) != ctx.tenant_id:
             raise HTTPException(400, f"User {rid} not found or not in tenant")
+        if ROLE_REVIEWER not in get_user_roles(reviewer_user.id, session):
+            raise HTTPException(
+                422,
+                f"User {rid} does not have the '{ROLE_REVIEWER}' role and cannot be assigned as reviewer",
+            )
         new_reviewers.add(UUID(rid))
-    
+
     # Sync reviewers directly in report_review table
     added, removed = _sync_report_reviewers(
         session=session,

--- a/app/api/v1/reports.py
+++ b/app/api/v1/reports.py
@@ -12,7 +12,7 @@ from app.models.storage import StorageObject
 from app.models.user import AppUser
 from app.models.audit import AuditLog
 from app.models.enums import ReportStatus, AssignmentItemType, ReviewStatus
-from app.core.rbac import has_permission
+from app.core.rbac import has_permission, has_any_role, ROLE_REVIEWER
 from app.models.assignment import Assignment
 from app.models.report_review import ReportReview
 from app.services.s3 import S3Service
@@ -36,6 +36,7 @@ from app.schemas.report import (
     ReportTemplateResponse,
     ReportTemplateDetailResponse,
     ReportTemplatesListResponse,
+    SignatureMetadata,
 )
 from app.schemas.laboratory import ReportFullDetailResponse
 import json
@@ -1463,10 +1464,12 @@ def sign_report(
     ctx: AuthContext = Depends(get_auth_ctx),
     user: AppUser = Depends(current_user),
 ):
-    """Sign and publish a report (APPROVED → PUBLISHED) — requires reports:sign."""
+    """Sign and publish a report (APPROVED → PUBLISHED) — requires reports:sign + 'reviewer' role."""
     if not has_permission(user.id, "reports:sign", session):
         raise HTTPException(403, "Permission required: reports:sign")
-    
+    if not has_any_role(user.id, {ROLE_REVIEWER}, session):
+        raise HTTPException(403, f"Only users with the '{ROLE_REVIEWER}' role can sign reports")
+
     report = session.get(Report, report_id)
     if not report:
         raise HTTPException(404, "Report not found")
@@ -1487,7 +1490,67 @@ def sign_report(
     
     if not current_version:
         raise HTTPException(404, "No current version found for this report")
-    
+
+    # If the persisted JSON requires a digital signature, embed the signer's
+    # PNG (presigned URL) into the document under signatureMetadata before
+    # finalising the signature.
+    if current_version.json_storage_id is not None:
+        json_storage = session.get(StorageObject, current_version.json_storage_id)
+        if json_storage is not None:
+            s3 = S3Service()
+            try:
+                raw_json = s3.download_text(json_storage.object_key)
+                report_doc = json.loads(raw_json)
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "Failed to load report JSON from S3 while signing",
+                    extra={
+                        "event": "report.sign_json_load_failed",
+                        "report_id": report_id,
+                        "object_key": json_storage.object_key,
+                        "error": str(exc),
+                    },
+                )
+                raise HTTPException(500, "Failed to load report content for signing")
+
+            metadata_dict = report_doc.get("signatureMetadata") or {}
+            try:
+                signature_meta = SignatureMetadata.model_validate(metadata_dict)
+            except Exception:
+                # Tolerate legacy or malformed metadata: fall back to defaults.
+                signature_meta = SignatureMetadata()
+
+            if signature_meta.require_digital_signature:
+                if user.signature_storage_id is None:
+                    raise HTTPException(
+                        422,
+                        "Cannot sign: the report requires a digital signature image but the signer has no signature uploaded",
+                    )
+                sig_storage = session.get(StorageObject, user.signature_storage_id)
+                if sig_storage is None:
+                    raise HTTPException(
+                        422,
+                        "Cannot sign: signer's signature storage object is missing",
+                    )
+                signature_url = s3.generate_presigned_url(sig_storage.object_key)
+                report_doc["signatureMetadata"] = {
+                    **metadata_dict,
+                    "show_signature_section": True,
+                    "require_digital_signature": True,
+                    "signature_url": signature_url,
+                }
+
+                updated_bytes = json.dumps(report_doc, ensure_ascii=False).encode("utf-8")
+                info = s3.upload_bytes(
+                    updated_bytes,
+                    key=json_storage.object_key,
+                    content_type="application/json",
+                )
+                json_storage.etag = info.etag
+                json_storage.size_bytes = info.size_bytes
+                json_storage.version_id = info.version_id
+                session.add(json_storage)
+
     # Update version with signature
     current_version.signed_by = user.id
     current_version.signed_at = datetime.utcnow()

--- a/app/api/v1/reports.py
+++ b/app/api/v1/reports.py
@@ -1532,7 +1532,13 @@ def sign_report(
                         422,
                         "Cannot sign: signer's signature storage object is missing",
                     )
-                signature_url = s3.generate_presigned_url(sig_storage.object_key)
+                # Use the public CDN URL (same pattern as avatars, sample images
+                # and /users/me/signature). Presigned S3 URLs would fail in the
+                # browser when the bucket is fronted by CloudFront with public
+                # access blocked at the S3 level. The signature object key is
+                # already unique per upload (timestamp-suffixed), so no cache
+                # buster query string is needed.
+                signature_url = s3.object_public_url(sig_storage.object_key)
                 report_doc["signatureMetadata"] = {
                     **metadata_dict,
                     "show_signature_section": True,

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -613,8 +613,8 @@ def _signature_object_key(user: AppUser) -> str:
     new object key. This sidesteps CloudFront's default behavior of ignoring
     query-string cache-busters: by changing the URL itself, the previous
     cached object becomes irrelevant and the CDN immediately serves the new
-    version. The previous object is removed from S3 and from `storage_object`
-    by `_delete_existing_signature`, so no orphan files accumulate.
+    version. DB rows are replaced on upload via `_delete_existing_signature`;
+    PNG objects intentionally remain in S3 so historically embedded CDN URLs keep working.
     """
     import time
     return f"users/{user.tenant_id}/{user.id}/signature/sign_{int(time.time())}.png"
@@ -625,24 +625,20 @@ def _require_reviewer(user: AppUser, session: Session) -> None:
         raise HTTPException(403, "Only users with the 'reviewer' role can manage a digital signature")
 
 
-def _delete_existing_signature(user: AppUser, session: Session, s3: S3Service) -> None:
-    """Best-effort removal of the user's previous signature in S3 and storage_object."""
+def _delete_existing_signature(user: AppUser, session: Session, _s3: S3Service) -> None:
+    """Detach the user's current signature StorageObject row and FK.
+
+    Does not delete the PNG from S3: report JSON snapshots embed ``signature_url``
+    pointing at those keys; deleting the object would break already-signed reports.
+    Older PNGs under ``users/<tenant>/<user>/signature/`` may accumulate unless a bucket
+    lifecycle rule is configured.
+
+    `_s3` is kept so callers stay unchanged even though soft-delete skips ``delete_object``.
+    """
     if user.signature_storage_id is None:
         return
     storage = session.get(StorageObject, user.signature_storage_id)
     if storage is not None:
-        try:
-            s3.delete_object(storage.object_key)
-        except Exception as exc:  # noqa: BLE001 — keep DB consistent even if S3 fails
-            logger.warning(
-                "Failed to delete previous signature object from S3",
-                extra={
-                    "event": "user.signature_s3_delete_failed",
-                    "user_id": str(user.id),
-                    "object_key": storage.object_key,
-                    "error": str(exc),
-                },
-            )
         session.delete(storage)
     user.signature_storage_id = None
 
@@ -737,7 +733,10 @@ def delete_my_signature(
     session: Session = Depends(get_session),
     user: AppUser = Depends(current_user),
 ):
-    """Delete the authenticated user's signature from S3 and storage_object."""
+    """Drop the user's current signature FK and DB StorageObject row only.
+
+    The PNG stays in S3 so previously signed reports retain a valid ``signature_url``.
+    """
     _require_reviewer(user, session)
 
     if user.signature_storage_id is None:

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -8,22 +8,29 @@ from app.core.rbac import (
     assign_role_by_code,
     replace_user_roles,
     has_permission,
+    has_any_role,
     user_has_full_branch_access,
     count_active_users_with_role,
+    ROLE_REVIEWER,
 )
 from app.models.user import AppUser, UserBranch
 from app.models.invitation import UserInvitation
 from app.models.tenant import Tenant, Branch
 from app.models.role import Role
 from app.models.user_role import UserRoleLink
+from app.models.storage import StorageObject
 from app.core.security import hash_password
 from app.core.config import settings
 from app.services.email import EmailService
+from app.services.s3 import S3Service
 from app.schemas.user import (
     UserCreateByAdmin,
     UserUpdateByAdmin,
     UserDetailResponse,
     UsersListResponse,
+    SignatureResponse,
+    ReviewerItem,
+    ReviewersListResponse,
 )
 from datetime import datetime, timedelta
 from typing import Optional
@@ -113,6 +120,55 @@ def list_users(
     ).all()
 
     return UsersListResponse(users=[_build_user_detail(u, session) for u in users])
+
+
+@router.get("/reviewers", response_model=ReviewersListResponse)
+def list_reviewers(
+    session: Session = Depends(get_session),
+    ctx: AuthContext = Depends(get_auth_ctx),
+    user: AppUser = Depends(current_user),
+):
+    """List active users in the tenant that hold the 'reviewer' role.
+
+    Used by the reviewer selector in the orders UI and by the reviewer
+    management screen under settings. Available to anyone able to manage
+    reviewers or users.
+    """
+    if not (
+        has_permission(user.id, "lab:manage_reviewers", session)
+        or has_permission(user.id, "admin:manage_users", session)
+    ):
+        raise HTTPException(403, "Permission required: lab:manage_reviewers or admin:manage_users")
+
+    rows = session.exec(
+        select(AppUser)
+        .join(UserRoleLink, UserRoleLink.user_id == AppUser.id)
+        .join(Role, Role.id == UserRoleLink.role_id)
+        .where(
+            AppUser.tenant_id == ctx.tenant_id,
+            AppUser.is_active == True,  # noqa: E712
+            Role.code == ROLE_REVIEWER,
+        )
+    ).all()
+
+    seen: set[str] = set()
+    reviewers: list[ReviewerItem] = []
+    for u in rows:
+        uid = str(u.id)
+        if uid in seen:
+            continue
+        seen.add(uid)
+        reviewers.append(
+            ReviewerItem(
+                id=uid,
+                full_name=u.full_name,
+                email=u.email,
+                has_signature=u.signature_storage_id is not None,
+                avatar_url=u.avatar_url,
+            )
+        )
+
+    return ReviewersListResponse(reviewers=reviewers)
 
 
 @router.post("/", response_model=UserDetailResponse)
@@ -540,3 +596,145 @@ def upload_user_avatar(
         extra={"event": "user.avatar_uploaded", "user_id": str(target_user.id)},
     )
     return {"message": "Avatar uploaded successfully", "avatar_url": target_user.avatar_url}
+
+
+# ---------------------------------------------------------------------------
+# Digital Signature (only available to users with role 'reviewer')
+# ---------------------------------------------------------------------------
+
+_SIGNATURE_MAX_BYTES = 2 * 1024 * 1024  # 2 MB
+
+
+def _signature_object_key(user: AppUser) -> str:
+    """S3 key layout for a reviewer's signature PNG.
+
+    Path is tenant-scoped so signatures are isolated per tenant in the bucket.
+    """
+    return f"users/{user.tenant_id}/{user.id}/signature/sign.png"
+
+
+def _require_reviewer(user: AppUser, session: Session) -> None:
+    if not has_any_role(user.id, {ROLE_REVIEWER}, session):
+        raise HTTPException(403, "Only users with the 'reviewer' role can manage a digital signature")
+
+
+def _delete_existing_signature(user: AppUser, session: Session, s3: S3Service) -> None:
+    """Best-effort removal of the user's previous signature in S3 and storage_object."""
+    if user.signature_storage_id is None:
+        return
+    storage = session.get(StorageObject, user.signature_storage_id)
+    if storage is not None:
+        try:
+            s3.delete_object(storage.object_key)
+        except Exception as exc:  # noqa: BLE001 — keep DB consistent even if S3 fails
+            logger.warning(
+                "Failed to delete previous signature object from S3",
+                extra={
+                    "event": "user.signature_s3_delete_failed",
+                    "user_id": str(user.id),
+                    "object_key": storage.object_key,
+                    "error": str(exc),
+                },
+            )
+        session.delete(storage)
+    user.signature_storage_id = None
+
+
+@router.post("/me/signature", response_model=SignatureResponse)
+def upload_my_signature(
+    file: UploadFile = File(...),
+    session: Session = Depends(get_session),
+    user: AppUser = Depends(current_user),
+):
+    """Upload (or replace) the authenticated user's digital signature PNG.
+
+    Only users with the 'reviewer' role are allowed to manage a signature.
+    """
+    _require_reviewer(user, session)
+
+    content_type = (file.content_type or "").lower()
+    if "png" not in content_type:
+        raise HTTPException(400, "Only PNG files are allowed for digital signatures")
+
+    file_bytes = file.file.read()
+    if not file_bytes:
+        raise HTTPException(400, "Uploaded file is empty")
+    if len(file_bytes) > _SIGNATURE_MAX_BYTES:
+        raise HTTPException(400, "Signature file size must be less than 2MB")
+
+    s3 = S3Service()
+    _delete_existing_signature(user, session, s3)
+    session.flush()
+
+    key = _signature_object_key(user)
+    info = s3.upload_bytes(file_bytes, key=key, content_type="image/png")
+
+    storage = StorageObject(
+        provider="aws",
+        region=s3.region,
+        bucket=info.bucket,
+        object_key=info.key,
+        version_id=info.version_id,
+        etag=info.etag,
+        content_type="image/png",
+        size_bytes=info.size_bytes,
+        created_by=user.id,
+    )
+    session.add(storage)
+    session.flush()
+
+    user.signature_storage_id = storage.id
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+
+    url = s3.generate_presigned_url(key)
+    logger.info(
+        f"Signature uploaded for user {user.email}",
+        extra={"event": "user.signature_uploaded", "user_id": str(user.id)},
+    )
+    return SignatureResponse(url=url, has_signature=True)
+
+
+@router.get("/me/signature", response_model=SignatureResponse)
+def get_my_signature(
+    session: Session = Depends(get_session),
+    user: AppUser = Depends(current_user),
+):
+    """Return a presigned URL for the authenticated user's signature.
+
+    Available to any authenticated user (so they can preview their own signature
+    even if they currently lack the reviewer role for some other reason).
+    """
+    if user.signature_storage_id is None:
+        raise HTTPException(404, "No signature uploaded for this user")
+    storage = session.get(StorageObject, user.signature_storage_id)
+    if storage is None:
+        raise HTTPException(404, "Signature object not found")
+
+    s3 = S3Service()
+    url = s3.generate_presigned_url(storage.object_key)
+    return SignatureResponse(url=url, has_signature=True)
+
+
+@router.delete("/me/signature", status_code=204)
+def delete_my_signature(
+    session: Session = Depends(get_session),
+    user: AppUser = Depends(current_user),
+):
+    """Delete the authenticated user's signature from S3 and storage_object."""
+    _require_reviewer(user, session)
+
+    if user.signature_storage_id is None:
+        return None
+
+    s3 = S3Service()
+    _delete_existing_signature(user, session, s3)
+    session.add(user)
+    session.commit()
+
+    logger.info(
+        f"Signature deleted for user {user.email}",
+        extra={"event": "user.signature_deleted", "user_id": str(user.id)},
+    )
+    return None

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -609,8 +609,15 @@ def _signature_object_key(user: AppUser) -> str:
     """S3 key layout for a reviewer's signature PNG.
 
     Path is tenant-scoped so signatures are isolated per tenant in the bucket.
+    The filename includes a unix-timestamp suffix so each upload writes to a
+    new object key. This sidesteps CloudFront's default behavior of ignoring
+    query-string cache-busters: by changing the URL itself, the previous
+    cached object becomes irrelevant and the CDN immediately serves the new
+    version. The previous object is removed from S3 and from `storage_object`
+    by `_delete_existing_signature`, so no orphan files accumulate.
     """
-    return f"users/{user.tenant_id}/{user.id}/signature/sign.png"
+    import time
+    return f"users/{user.tenant_id}/{user.id}/signature/sign_{int(time.time())}.png"
 
 
 def _require_reviewer(user: AppUser, session: Session) -> None:
@@ -688,7 +695,11 @@ def upload_my_signature(
     session.commit()
     session.refresh(user)
 
-    url = s3.generate_presigned_url(key)
+    # Use the public CDN URL (same pattern as avatars/sample images) so the
+    # browser <img> can load it through CloudFront. The S3 key itself already
+    # includes a unique suffix per upload (see `_signature_object_key`), so a
+    # query-string cache-buster is not needed.
+    url = s3.object_public_url(key)
     logger.info(
         f"Signature uploaded for user {user.email}",
         extra={"event": "user.signature_uploaded", "user_id": str(user.id)},
@@ -713,7 +724,11 @@ def get_my_signature(
         raise HTTPException(404, "Signature object not found")
 
     s3 = S3Service()
-    url = s3.generate_presigned_url(storage.object_key)
+    # Match avatar/sample-image pattern: serve through the public base URL
+    # (CloudFront) so browsers can fetch it directly via <img>. The object
+    # key stored in the DB is unique per upload (see `_signature_object_key`),
+    # so CloudFront is guaranteed to fetch the latest version.
+    url = s3.object_public_url(storage.object_key)
     return SignatureResponse(url=url, has_signature=True)
 
 

--- a/app/core/rbac.py
+++ b/app/core/rbac.py
@@ -22,6 +22,7 @@ from app.models.user import AppUser
 ROLE_SUPERUSER = "superuser"
 ROLE_ADMIN = "admin"
 ROLE_PATHOLOGIST = "pathologist"
+ROLE_REVIEWER = "reviewer"
 ROLE_LAB_TECH = "lab_tech"
 ROLE_ASSISTANT = "assistant"
 ROLE_BILLING = "billing"

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -22,6 +22,9 @@ class AppUser(BaseModel, TimestampMixin, TenantMixin, table=True):
     hashed_password: str = Field(max_length=255)
     is_active: bool = Field(default=True)
     avatar_url: Optional[str] = Field(max_length=500, default=None)
+    signature_storage_id: Optional[UUID] = Field(
+        default=None, foreign_key="storage_object.id"
+    )
 
     # Basic relationships
     tenant: "Tenant" = Relationship(back_populates="users")

--- a/app/schemas/report.py
+++ b/app/schemas/report.py
@@ -2,6 +2,19 @@ from pydantic import BaseModel
 from typing import Optional, Dict, Any, List
 from datetime import datetime
 
+
+class SignatureMetadata(BaseModel):
+    """Metadata that controls the digital signature block of a report.
+
+    Persisted inside the JSON body stored in the bucket (alongside `base` and
+    `sections`), not in columns of the `report` table. Templates carry the
+    defaults; reports can override them until publication.
+    """
+    show_signature_section: bool = False
+    require_digital_signature: bool = False
+    signature_url: Optional[str] = None
+
+
 # Import ReviewerWithStatus from worklist schema
 class ReviewerWithStatus(BaseModel):
     """User with review status"""

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -72,3 +72,23 @@ class UserDetailResponse(BaseModel):
 class UsersListResponse(BaseModel):
     """Schema for users list response"""
     users: List[UserDetailResponse]
+
+
+class SignatureResponse(BaseModel):
+    """Response for current user's digital signature."""
+    url: str
+    has_signature: bool
+
+
+class ReviewerItem(BaseModel):
+    """User entry tailored for the reviewer selector / management screens."""
+    id: str
+    full_name: str
+    email: str
+    has_signature: bool
+    avatar_url: Optional[str] = None
+
+
+class ReviewersListResponse(BaseModel):
+    """Response schema for the list of users with the reviewer role."""
+    reviewers: List[ReviewerItem]

--- a/app/services/s3.py
+++ b/app/services/s3.py
@@ -113,4 +113,8 @@ class S3Service:
     def download_text(self, key: str, encoding: str = "utf-8") -> str:
         return self.download_bytes(key).decode(encoding)
 
+    def delete_object(self, key: str) -> None:
+        """Delete an object from the configured bucket. No-op if it does not exist."""
+        self._client.delete_object(Bucket=self.bucket, Key=key)
+
 

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -11,30 +11,11 @@ services:
     volumes: ["pgdata:/var/lib/postgresql/data"]
     restart: unless-stopped
 
-  db-init:
-    image: ghcr.io/celuma/celuma-backend:latest
-    pull_policy: always
-    env_file: .env
-    environment:
-      - APP_NAME=${APP_NAME:-celuma}
-      - ENV=${ENV:-dev}
-      - DATABASE_URL=${DATABASE_URL:-postgresql+psycopg2://postgres:postgres@db:5432/celumadb}
-      - JWT_SECRET=${JWT_SECRET}
-      - JWT_EXPIRES_MIN=${JWT_EXPIRES_MIN:-480}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-      - AWS_REGION=${AWS_REGION}
-      - S3_BUCKET_NAME=${S3_BUCKET_NAME}
-      - MEDIA_PUBLIC_BASE_URL=${MEDIA_PUBLIC_BASE_URL}
-      - MEDIA_PRESIGNED_EXPIRE_SECONDS=${MEDIA_PRESIGNED_EXPIRE_SECONDS:-3600}
-      - S3_ENDPOINT_URL=${S3_ENDPOINT_URL}
-    command: bash init_db.sh
-    restart: "no"
-
   api:
     image: ghcr.io/celuma/celuma-backend:latest
     pull_policy: always
     env_file: .env
+    command: bash start.sh
     environment:
       - DATABASE_URL=${DATABASE_URL:-postgresql+psycopg2://postgres:postgres@db:5432/celumadb}
       - JWT_SECRET=${JWT_SECRET}
@@ -50,7 +31,7 @@ services:
       - S3_ENDPOINT_URL=${S3_ENDPOINT_URL}
     ports: ["8000:8000"]
     depends_on:
-      - db-init
+      - db
     restart: unless-stopped
 
 volumes:

--- a/docker-compose.remote-db.yml
+++ b/docker-compose.remote-db.yml
@@ -6,30 +6,10 @@ version: '3.8'
 #   docker compose -f docker-compose.remote-db.yml up -d
 
 services:
-  db-init:
-    image: ghcr.io/celuma/celuma-backend:latest
-    env_file: .env
-    environment:
-      - DATABASE_URL=${DATABASE_URL}
-      - JWT_SECRET=${JWT_SECRET}
-      - JWT_EXPIRES_MIN=${JWT_EXPIRES_MIN:-480}
-      - APP_NAME=${APP_NAME:-celuma}
-      - ENV=${ENV:-production}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-      - AWS_REGION=${AWS_REGION}
-      - S3_BUCKET_NAME=${S3_BUCKET_NAME}
-      - MEDIA_PUBLIC_BASE_URL=${MEDIA_PUBLIC_BASE_URL}
-      - MEDIA_PRESIGNED_EXPIRE_SECONDS=${MEDIA_PRESIGNED_EXPIRE_SECONDS:-3600}
-      - S3_ENDPOINT_URL=${S3_ENDPOINT_URL}
-    command: bash init_db.sh
-    restart: "no"
-    networks:
-      - celuma-network
-
   api:
     image: ghcr.io/celuma/celuma-backend:latest
     env_file: .env
+    command: bash start.sh
     environment:
       - DATABASE_URL=${DATABASE_URL}
       - JWT_SECRET=${JWT_SECRET}
@@ -44,8 +24,6 @@ services:
       - MEDIA_PRESIGNED_EXPIRE_SECONDS=${MEDIA_PRESIGNED_EXPIRE_SECONDS:-3600}
       - S3_ENDPOINT_URL=${S3_ENDPOINT_URL}
     ports: ["8000:8000"]
-    depends_on:
-      - db-init
     restart: unless-stopped
     networks:
       - celuma-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,25 +8,15 @@ services:
     ports: ["5432:5432"]
     volumes: ["pgdata:/var/lib/postgresql/data"]
 
-  db-init:
-    build: .
-    env_file: .env
-    command: bash init_db.sh
-    volumes:
-      - .:/app
-    depends_on:
-      - db
-    restart: "no"
-
   api:
     build: .
     env_file: .env
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    command: bash start.sh
     volumes:
       - .:/app
     ports: ["8000:8000"]
     depends_on:
-      - db-init
+      - db
     environment:
       - DATABASE_URL=${DATABASE_URL:-postgresql+psycopg2://postgres:postgres@db:5432/celumadb}
       - JWT_SECRET=${JWT_SECRET}

--- a/start.sh
+++ b/start.sh
@@ -62,14 +62,19 @@ if [ $attempt -gt $max_attempts ]; then
     exit 1
 fi
 
-# Run migrations
-echo "Running database migrations..."
-if alembic upgrade head; then
-    echo "Migrations completed successfully!"
+# Run migrations (only if not already at head)
+echo "Checking migration status..."
+if alembic current 2>/dev/null | grep -q "(head)"; then
+    echo "Database is already up to date, skipping migrations."
 else
-    echo "ERROR: Migrations failed!"
-    echo "You can run migrations manually with: alembic upgrade head"
-    echo "Continuing anyway..."
+    echo "Running database migrations..."
+    if alembic upgrade head; then
+        echo "Migrations completed successfully!"
+    else
+        echo "ERROR: Migrations failed!"
+        echo "You can run migrations manually with: alembic upgrade head"
+        exit 1
+    fi
 fi
 
 # Start the application


### PR DESCRIPTION
This pull request introduces digital signature support for report reviewers, including backend support for uploading, storing, and embedding reviewer signatures in signed reports. It also adds a new "reviewer" system role with appropriate permissions, enforces role-based access for reviewer actions, and provides new endpoints for managing reviewer signatures.

**Key changes:**

### Database and Role Management

* Alembic migration adds a nullable `signature_storage_id` column (foreign key to `storage_object.id`) to the `app_user` table, seeds a new `reviewer` system role with permissions (`reports:read`, `reports:approve`, `reports:sign`, `lab:read`, `lab:manage_reviewers`), and removes `reports:sign` from the `pathologist` role. Downgrade reverses these changes.
* The `AppUser` model is updated to include the new `signature_storage_id` field.
* The RBAC module now defines the `ROLE_REVIEWER` constant.

### Reviewer Role Enforcement and APIs

* Reviewer assignment in orders now validates that assigned users have the `reviewer` role.
* The report signing endpoint requires both the `reports:sign` permission and the `reviewer` role.
* New `/users/reviewers` endpoint lists all active users with the reviewer role in the tenant, for use in reviewer management UIs.

### Digital Signature Management

* Adds endpoints for reviewers to upload, retrieve, and delete their digital signature PNG files, storing them in S3 and tracking via `storage_object`. Only users with the `reviewer` role can manage their signature.
* S3 service now supports deleting objects.

### Report Signing Workflow

* When a report requires a digital signature, the signer's signature image is embedded as a presigned URL into the report's JSON before finalizing the signature.
* Introduces a `SignatureMetadata` schema to manage signature-related metadata in report documents.

### API Schemas

* Adds `SignatureResponse`, `ReviewerItem`, and `ReviewersListResponse` schemas for digital signature and reviewer management endpoints.

These changes collectively enable secure, auditable digital signature workflows for report reviewers, with robust role-based access and full lifecycle management of reviewer signature images.