### PR TITLE
Enhance user model with first and last name fields

### DIFF
--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -87,6 +87,8 @@ def _build_user_detail(u: AppUser, session: Session) -> UserDetailResponse:
         tenant_id=str(u.tenant_id),
         email=u.email,
         username=u.username,
+        first_name=u.first_name,
+        last_name=u.last_name,
         full_name=u.full_name,
         roles=get_user_roles(u.id, session),
         is_active=u.is_active,
@@ -269,7 +271,18 @@ def update_user(
         target_user.email = user_data.email
     if user_data.username is not None:
         target_user.username = user_data.username
-    if user_data.full_name is not None:
+    # Name: first/last are the source of truth; full_name is derived from them.
+    # full_name is still honored on its own for backward compatibility.
+    name_changed = False
+    if user_data.first_name is not None:
+        target_user.first_name = user_data.first_name
+        name_changed = True
+    if user_data.last_name is not None:
+        target_user.last_name = user_data.last_name
+        name_changed = True
+    if name_changed:
+        target_user.full_name = f"{target_user.first_name or ''} {target_user.last_name or ''}".strip()
+    elif user_data.full_name is not None:
         target_user.full_name = user_data.full_name
     if user_data.is_active is not None:
         target_user.is_active = user_data.is_active

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -37,12 +37,15 @@ class UserUpdateByAdmin(BaseModel):
     """Schema for admin updating a user"""
     email: Optional[str] = None
     username: Optional[str] = None
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    # full_name still accepted for backward compatibility; first/last take precedence.
     full_name: Optional[str] = None
     role: Optional[str] = None
     is_active: Optional[bool] = None
     password: Optional[str] = None
     branch_ids: Optional[List[str]] = None
-    
+
     @field_validator('username')
     @classmethod
     def validate_username(cls, v: Optional[str]) -> Optional[str]:
@@ -62,6 +65,8 @@ class UserDetailResponse(BaseModel):
     tenant_id: str
     email: str
     username: Optional[str] = None
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
     full_name: str
     roles: List[str] = []
     is_active: bool


### PR DESCRIPTION
This pull request updates how user names are handled in the user management API to support separate `first_name` and `last_name` fields, while retaining `full_name` for backward compatibility. The changes ensure that `first_name` and `last_name` are the primary sources of truth, and `full_name` is derived from them if provided. The API schemas and response models are updated accordingly.

**User name handling improvements:**

* Added `first_name` and `last_name` fields to the `UserDetailResponse` and `UserUpdateByAdmin` schemas in `app/schemas/user.py`, with logic that gives precedence to these fields over `full_name` for updates and responses. [[1]](diffhunk://#diff-246b0dd351a605a4ff042cceb46d15ceeb2842bf7e2645169bdd0ec1dc1b6b5eR40-R42) [[2]](diffhunk://#diff-246b0dd351a605a4ff042cceb46d15ceeb2842bf7e2645169bdd0ec1dc1b6b5eR68-R69)
* Updated the `_build_user_detail` function in `app/api/v1/users.py` to include `first_name` and `last_name` in the user detail response.
* Modified the `update_user` function in `app/api/v1/users.py` to update `first_name` and `last_name` as the primary fields, and automatically derive `full_name` from them unless only `full_name` is provided (for backward compatibility).