### PR TITLE
Harden backend repository and CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      python-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 5

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+- What changed and why?
+
+## Validation
+
+- [ ] Critical lint checks pass
+- [ ] Unit and integration tests pass
+- [ ] Container build passes
+- [ ] Relevant manual checks are documented
+
+## Céluma safeguards
+
+- [ ] No secrets, credentials, patient data, or tenant data are included
+- [ ] Role, permission, tenant-isolation, and audit impacts were reviewed
+- [ ] Schema migration, deployment, and rollback impacts are documented or not applicable
+- [ ] This PR does not mix unrelated functional and infrastructure changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   docker-build-main:
     runs-on: ubuntu-latest
@@ -88,6 +91,7 @@ jobs:
     needs: docker-build-main
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    environment: stg
 
     permissions:
       id-token: write   # OIDC for AWS
@@ -211,6 +215,9 @@ jobs:
     if: >
       github.event_name == 'push' &&
       startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: prod
+      url: https://app.celuma.mx/api
 
     permissions:
       id-token: write   # OIDC for AWS

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - main
+      - celuma-1.3
+
+permissions:
+  contents: read
 
 # Prevents duplicate builds from multiple pushes on the same PR
 concurrency:
@@ -13,10 +17,24 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: celuma_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d celuma_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     env:
-      DATABASE_URL: ${{ vars.DATABASE_URL }}
-      JWT_SECRET: ${{ vars.JWT_SECRET }}
-      JWT_EXPIRES_MIN: ${{ vars.JWT_EXPIRES_MIN }}
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/celuma_test
+      JWT_SECRET: ci-only-secret-not-used-outside-tests
+      JWT_EXPIRES_MIN: 30
     steps:
       - uses: actions/checkout@v4
       
@@ -38,6 +56,10 @@ jobs:
       - name: Install dependencies
         run: make install-dev
         shell: bash
+
+      - name: Lint
+        run: make lint
+        shell: bash
       
       - name: Run unit tests
         run: make test-unit
@@ -47,7 +69,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     # Only runs if tests passed
-    if: needs.test.result == 'success'
+    if: >-
+      needs.test.result == 'success' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     
     permissions:
       contents: read

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup install install-dev test-unit build clean
+.PHONY: help setup install install-dev lint test-unit build clean
 
 help: ## Show this help message
 	@echo "Celuma API - Available Commands:"
@@ -14,6 +14,9 @@ install: ## Install runtime dependencies only (what the production image ships)
 
 install-dev: ## Install runtime + test dependencies (use this to run the suite)
 	python3 -m pip install -r requirements-dev.txt
+
+lint: ## Run critical Python static checks
+	python3 -m ruff check app tests alembic
 
 test-unit: ## Run unit tests with coverage
 	python3 -m pytest --cov=app --cov-branch --cov-report=xml --cov-report=term-missing --cov-report=html

--- a/app/models/laboratory.py
+++ b/app/models/laboratory.py
@@ -1,10 +1,13 @@
 from datetime import datetime
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, TYPE_CHECKING
 from uuid import UUID, uuid4
 from sqlmodel import SQLModel, Field, Relationship, Column
 from sqlalchemy import JSON
 from .base import BaseModel, TimestampMixin, TenantMixin, BranchMixin
 from .enums import OrderStatus, SampleType, SampleState
+
+if TYPE_CHECKING:
+    from .storage import SampleImageRendition
 
 class Order(BaseModel, TimestampMixin, TenantMixin, BranchMixin, table=True):
     """Laboratory order model

--- a/app/models/storage.py
+++ b/app/models/storage.py
@@ -1,8 +1,11 @@
 from datetime import datetime
-from typing import Optional, List
+from typing import Optional, List, TYPE_CHECKING
 from uuid import UUID, uuid4
 from sqlmodel import SQLModel, Field, Relationship
 from .base import BaseModel, TimestampMixin
+
+if TYPE_CHECKING:
+    from .laboratory import SampleImage
 
 class StorageObject(BaseModel, TimestampMixin, table=True):
     """Storage object model for S3 and other cloud storage"""

--- a/app/models/tenant.py
+++ b/app/models/tenant.py
@@ -1,8 +1,11 @@
 from datetime import datetime
-from typing import Optional, List
+from typing import Optional, List, TYPE_CHECKING
 from uuid import UUID, uuid4
 from sqlmodel import SQLModel, Field, Relationship
 from .base import BaseModel, TimestampMixin
+
+if TYPE_CHECKING:
+    from .user import AppUser, UserBranch
 
 class Tenant(BaseModel, TimestampMixin, table=True):
     """Tenant model for multi-tenancy"""

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -5,6 +5,7 @@ from sqlmodel import SQLModel, Field, Relationship
 from .base import BaseModel, TimestampMixin, TenantMixin
 
 if TYPE_CHECKING:
+    from .tenant import Branch, Tenant
     from .user_role import UserRoleLink
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@
 
 pytest==8.4.1
 pytest-cov==6.2.1
+ruff==0.12.*
 
 # httpx is required by fastapi.testclient.TestClient, which only the HTTP
 # integration tests use — no application module imports it.

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,4 @@
+target-version = "py312"
+
+[lint]
+select = ["E9", "F63", "F7", "F82"]

--- a/tests/http/factories.py
+++ b/tests/http/factories.py
@@ -6,7 +6,7 @@ complex testing framework").
 """
 import uuid
 from datetime import datetime, timedelta
-from typing import Iterable, Optional
+from typing import TYPE_CHECKING, Iterable, Optional
 
 from sqlmodel import Session
 
@@ -18,6 +18,10 @@ from app.models.report_template_version import ReportTemplateVersion, ReportTemp
 from app.models.storage import StorageObject
 from app.models.tenant import Branch, Tenant
 from app.models.user import AppUser
+
+if TYPE_CHECKING:
+    from app.models.report_letterhead import ReportLetterhead
+    from app.models.report_letterhead_version import ReportLetterheadVersion
 
 
 # Céluma 1.3 Phase 2, Block B, Story B10: the RBAC catalog (permissions,


### PR DESCRIPTION
## What changed
- provisions isolated PostgreSQL 16 for PR tests
- removes CI dependency on deployment database variables
- adds a critical Ruff lint baseline
- adds Dependabot and a Céluma safety checklist
- associates staging and production deploys with GitHub environments
- keeps runtime and development dependencies separated

## Why
The current PR check resolves DATABASE_URL to the Docker-only host `db`, causing 242 setup errors. The repository also lacked a static-analysis gate and deployment history.

## Validation
- Ruff: passed
- pytest: 418 passed, 10 skipped

No functional Phase 3 scope is included.